### PR TITLE
LINQ to XML for WP7 and references.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ TestResults
 packages/
 
 Xamarin/
+
+#ReSharper
+_ReSharper.*

--- a/PushSharp.Android/C2dm/AndroidFluentNotification.cs
+++ b/PushSharp.Android/C2dm/AndroidFluentNotification.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using PushSharp.Android;
+﻿using PushSharp.Android;
 
 namespace PushSharp
 {

--- a/PushSharp.Android/C2dm/AndroidNotification.cs
+++ b/PushSharp.Android/C2dm/AndroidNotification.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
 using System.Text;
 using System.Web;
 using PushSharp.Common;

--- a/PushSharp.Android/C2dm/AndroidPushChannel.cs
+++ b/PushSharp.Android/C2dm/AndroidPushChannel.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
 using System.Net;
 using System.Text;
 using PushSharp.Common;

--- a/PushSharp.Android/C2dm/AndroidPushChannelSettings.cs
+++ b/PushSharp.Android/C2dm/AndroidPushChannelSettings.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using PushSharp.Common;
 
 namespace PushSharp.Android

--- a/PushSharp.Android/C2dm/AndroidPushService.cs
+++ b/PushSharp.Android/C2dm/AndroidPushService.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using PushSharp.Common;
 
 namespace PushSharp.Android

--- a/PushSharp.Android/C2dm/C2dmExceptions.cs
+++ b/PushSharp.Android/C2dm/C2dmExceptions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace PushSharp.Android
 {

--- a/PushSharp.Android/C2dm/C2dmMessageTransportAsync.cs
+++ b/PushSharp.Android/C2dm/C2dmMessageTransportAsync.cs
@@ -1,12 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Net;
 using System.IO;
-using System.Security.Cryptography.X509Certificates;
-using System.Security;
-using System.Net.Security;
 
 namespace PushSharp.Android
 {

--- a/PushSharp.Android/C2dm/C2dmMessageTransportResponse.cs
+++ b/PushSharp.Android/C2dm/C2dmMessageTransportResponse.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PushSharp.Android
+﻿namespace PushSharp.Android
 {
 	public class C2dmMessageTransportResponse
 	{

--- a/PushSharp.Android/Gcm/GcmExceptions.cs
+++ b/PushSharp.Android/Gcm/GcmExceptions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace PushSharp.Android
 {

--- a/PushSharp.Android/Gcm/GcmFluentNotification.cs
+++ b/PushSharp.Android/Gcm/GcmFluentNotification.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using PushSharp.Android;
 
 namespace PushSharp

--- a/PushSharp.Android/Gcm/GcmMessageTransportResponse.cs
+++ b/PushSharp.Android/Gcm/GcmMessageTransportResponse.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace PushSharp.Android
 {

--- a/PushSharp.Android/Gcm/GcmPushChannel.cs
+++ b/PushSharp.Android/Gcm/GcmPushChannel.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Linq;
-using System.Net;
-using System.Text;
 using PushSharp.Common;
 
 namespace PushSharp.Android

--- a/PushSharp.Android/Gcm/GcmPushChannelSettings.cs
+++ b/PushSharp.Android/Gcm/GcmPushChannelSettings.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using PushSharp.Common;
+﻿using PushSharp.Common;
 
 namespace PushSharp.Android
 {

--- a/PushSharp.Android/Gcm/GcmPushService.cs
+++ b/PushSharp.Android/Gcm/GcmPushService.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using PushSharp.Common;
+﻿using PushSharp.Common;
 
 namespace PushSharp.Android
 {

--- a/PushSharp.Apple/AppleFluentNotification.cs
+++ b/PushSharp.Apple/AppleFluentNotification.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using PushSharp.Apple;
-using PushSharp.Common;
 
-namespace PushSharp
+namespace PushSharp.Apple
 {
 	public static class FluentNotification
 	{

--- a/PushSharp.Apple/AppleNotification.cs
+++ b/PushSharp.Apple/AppleNotification.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Json;
 using System.Text;
-using System.ServiceModel.Web;
 
 namespace PushSharp.Apple
 {

--- a/PushSharp.Apple/AppleNotificationAlert.cs
+++ b/PushSharp.Apple/AppleNotificationAlert.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 //using Newtonsoft.Json.Linq;
 
 namespace PushSharp.Apple

--- a/PushSharp.Apple/ApplePushChannel.cs
+++ b/PushSharp.Apple/ApplePushChannel.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
 using System.Security.Cryptography.X509Certificates;
-using System.Linq;
 using System.Net.Sockets;
 using System.Net.Security;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Net;

--- a/PushSharp.Apple/ApplePushChannelSettings.cs
+++ b/PushSharp.Apple/ApplePushChannelSettings.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PushSharp.Apple
+﻿namespace PushSharp.Apple
 {
 	public class ApplePushChannelSettings : Common.PushChannelSettings
 	{

--- a/PushSharp.Apple/ApplePushService.cs
+++ b/PushSharp.Apple/ApplePushService.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using PushSharp.Common;
 
 namespace PushSharp.Apple

--- a/PushSharp.Apple/Exceptions.cs
+++ b/PushSharp.Apple/Exceptions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace PushSharp.Apple
 {

--- a/PushSharp.Apple/FeedbackService.cs
+++ b/PushSharp.Apple/FeedbackService.cs
@@ -1,13 +1,9 @@
 ﻿﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using System.Threading;
-using System.Net;
-using System.Net.Sockets;
+﻿using System.Net.Sockets;
 using System.Net.Security;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
+﻿using System.Security.Cryptography.X509Certificates;
 
 namespace PushSharp.Apple
 {

--- a/PushSharp.Blackberry/BlackberryNotification.cs
+++ b/PushSharp.Blackberry/BlackberryNotification.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.IO;
-using System.Net;
-using PushSharp.Common;
+﻿using PushSharp.Common;
 
 namespace PushSharp.Blackberry
 {

--- a/PushSharp.Blackberry/BlackberryPushChannel.cs
+++ b/PushSharp.Blackberry/BlackberryPushChannel.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Text;
 

--- a/PushSharp.Blackberry/BlackberryPushChannelSettings.cs
+++ b/PushSharp.Blackberry/BlackberryPushChannelSettings.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PushSharp.Blackberry
+﻿namespace PushSharp.Blackberry
 {
 	public class BlackberryPushChannelSettings : Common.PushChannelSettings
 	{

--- a/PushSharp.Blackberry/BlackberryPushService.cs
+++ b/PushSharp.Blackberry/BlackberryPushService.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PushSharp.Blackberry
+﻿namespace PushSharp.Blackberry
 {
 	public class BlackberryPushService : Common.PushServiceBase
 	{

--- a/PushSharp.Common/AssemblyVersionInfo.cs
+++ b/PushSharp.Common/AssemblyVersionInfo.cs
@@ -1,6 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 // Version information for an assembly consists of the following four values:
 //

--- a/PushSharp.Common/ChannelEvents.cs
+++ b/PushSharp.Common/ChannelEvents.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace PushSharp.Common
 {

--- a/PushSharp.Common/Exceptions.cs
+++ b/PushSharp.Common/Exceptions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace PushSharp.Common
 {

--- a/PushSharp.Common/Notification.cs
+++ b/PushSharp.Common/Notification.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace PushSharp.Common
 {

--- a/PushSharp.Common/PlatformType.cs
+++ b/PushSharp.Common/PlatformType.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PushSharp.Common
+﻿namespace PushSharp.Common
 {
 	public enum PlatformType
 	{

--- a/PushSharp.Common/PushChannelBase.cs
+++ b/PushSharp.Common/PushChannelBase.cs
@@ -1,14 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
-using System.Security.Cryptography.X509Certificates;
-using System.Linq;
-using System.Net.Sockets;
-using System.Net.Security;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Net;
 
 namespace PushSharp.Common
 {

--- a/PushSharp.Common/PushChannelSettings.cs
+++ b/PushSharp.Common/PushChannelSettings.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PushSharp.Common
+﻿namespace PushSharp.Common
 {
 	public abstract class PushChannelSettings
 	{

--- a/PushSharp.Common/PushServiceBase.cs
+++ b/PushSharp.Common/PushServiceBase.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -40,7 +39,7 @@ namespace PushSharp.Common
 			
 			CheckScale();
 
-			distributerTask = new Task(() => { Distributer(); }, TaskCreationOptions.LongRunning);
+			distributerTask = new Task(Distributer, TaskCreationOptions.LongRunning);
 			distributerTask.ContinueWith((ft) =>
 			{
 				var ex = ft.Exception;

--- a/PushSharp.Common/PushServiceSettings.cs
+++ b/PushSharp.Common/PushServiceSettings.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PushSharp.Common
+﻿namespace PushSharp.Common
 {
 	public class PushServiceSettings
 	{

--- a/PushSharp.Common/PushSettings.cs
+++ b/PushSharp.Common/PushSettings.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PushSharp.Common
+﻿namespace PushSharp.Common
 {
 	public class PushSettings
 	{

--- a/PushSharp.Sample/Program.cs
+++ b/PushSharp.Sample/Program.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.IO;
-using System.Linq;
-using System.Text;
-using PushSharp;
 using PushSharp.Apple;
 using PushSharp.Android;
 

--- a/PushSharp.WindowsPhone/Exceptions.cs
+++ b/PushSharp.WindowsPhone/Exceptions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace PushSharp.WindowsPhone
 {

--- a/PushSharp.WindowsPhone/WindowsPhoneMessageStatus.cs
+++ b/PushSharp.WindowsPhone/WindowsPhoneMessageStatus.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace PushSharp.WindowsPhone
 {

--- a/PushSharp.WindowsPhone/WindowsPhonePushChannel.cs
+++ b/PushSharp.WindowsPhone/WindowsPhonePushChannel.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Text;
 using PushSharp.Common;

--- a/PushSharp.WindowsPhone/WindowsPhonePushChannelSettings.cs
+++ b/PushSharp.WindowsPhone/WindowsPhonePushChannelSettings.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using PushSharp.Common;
+﻿using PushSharp.Common;
 
 namespace PushSharp.WindowsPhone
 {

--- a/PushSharp.WindowsPhone/WindowsPhonePushFluent.cs
+++ b/PushSharp.WindowsPhone/WindowsPhonePushFluent.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using PushSharp.WindowsPhone;
 
 namespace PushSharp

--- a/PushSharp.WindowsPhone/WindowsPhonePushService.cs
+++ b/PushSharp.WindowsPhone/WindowsPhonePushService.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using PushSharp.Common;
+﻿using PushSharp.Common;
 
 namespace PushSharp.WindowsPhone
 {

--- a/PushSharp.WindowsPhone/WindowsPhoneTransportResponse.cs
+++ b/PushSharp.WindowsPhone/WindowsPhoneTransportResponse.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace PushSharp.WindowsPhone
+﻿namespace PushSharp.WindowsPhone
 {
 	public class WindowsPhoneTransportResponse
 	{

--- a/PushSharp/NotificationFactory.cs
+++ b/PushSharp/NotificationFactory.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace PushSharp
 {

--- a/PushSharp/PushService.cs
+++ b/PushSharp/PushService.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using PushSharp.Common;
 


### PR DESCRIPTION
Removed unused references and code is now using LINQ to XML for creating WP7 notifications.
