### PR TITLE
Added default value for PushChannelBase.ServerSettings

### DIFF
--- a/PushSharp.Common/PushChannelBase.cs
+++ b/PushSharp.Common/PushChannelBase.cs
@@ -40,7 +40,7 @@ namespace PushSharp.Common
 			this.queuedNotifications = new ConcurrentQueue<Notification>();
 		
 			this.ChannelSettings = channelSettings;
-			this.ServiceSettings = serviceSettings;
+            this.ServiceSettings = serviceSettings ?? new PushServiceSettings();
 
 			//Start our sending task
 			taskSender = new Task(() => Sender(), TaskCreationOptions.LongRunning);


### PR DESCRIPTION
It was possible for ServiceSettings to be null, causing QueueNotifcation() to suffer a hard failure.
