### PR TITLE
Minimum average time added, below which no new channels are created

### DIFF
--- a/PushSharp.Common/PushServiceBase.cs
+++ b/PushSharp.Common/PushServiceBase.cs
@@ -141,20 +141,20 @@ namespace PushSharp.Common
 
 				var avgTime = GetAverageQueueWait();
 
-				if (avgTime < 100 && channels.Count > 1)
+                if (avgTime < ServiceSettings.MinAvgTimeToScaleChannels && channels.Count > 1)
 				{
 					ScaleChannels(ChannelScaleAction.Destroy);
 				}
 				else if (channels.Count < this.ServiceSettings.MaxAutoScaleChannels)
 				{
-					var numChannelsToSpinUp = 1;
+					var numChannelsToSpinUp = 0;
 
 					//Depending on the wait time, let's spin up more than 1 channel at a time
 					if (avgTime > 5000)
 						numChannelsToSpinUp = 5;
 					else if (avgTime > 1000)
 						numChannelsToSpinUp = 2;
-					else if (avgTime > 100)
+					else if (avgTime > ServiceSettings.MinAvgTimeToScaleChannels)
 						numChannelsToSpinUp = 1;
 
 					ScaleChannels(ChannelScaleAction.Create, numChannelsToSpinUp);

--- a/PushSharp.Common/PushServiceSettings.cs
+++ b/PushSharp.Common/PushServiceSettings.cs
@@ -11,14 +11,15 @@ namespace PushSharp.Common
 		{
 			this.AutoScaleChannels = true;
 			this.MaxAutoScaleChannels = 100;
+            this.MinAvgTimeToScaleChannels = 100;
 			this.Channels = 1;
 			this.MaxNotificationRequeues = 5;
 		}
 
 		public bool AutoScaleChannels { get; set; }
 		public int MaxAutoScaleChannels { get; set; }
+        public long MinAvgTimeToScaleChannels { get; set; }
 		public int Channels { get; set; }
-
 		public int MaxNotificationRequeues { get; set; }
 	}
 }


### PR DESCRIPTION
Configurable minimum average waiting time in the queue, below which no
new channels are created, and above which no channels are destroyed.
