### PR TITLE
Added certificate support for Windows Phone

### DIFF
--- a/PushSharp.WindowsPhone/WindowsPhonePushChannel.cs
+++ b/PushSharp.WindowsPhone/WindowsPhonePushChannel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using PushSharp.Common;
 
@@ -10,10 +11,12 @@ namespace PushSharp.WindowsPhone
 	public class WindowsPhonePushChannel : PushChannelBase
 	{
 		WindowsPhonePushChannelSettings windowsPhoneSettings;
+		X509Certificate2 certificate;
 
 		public WindowsPhonePushChannel(WindowsPhonePushChannelSettings channelSettings, PushServiceSettings serviceSettings = null) : base(channelSettings, serviceSettings)
 		{
 			windowsPhoneSettings = channelSettings;
+			certificate = channelSettings.Certificate;
 		}
 
         public override PlatformType PlatformType
@@ -72,6 +75,9 @@ namespace PushSharp.WindowsPhone
 			var data = Encoding.Default.GetBytes(payload);
 
 			wr.ContentLength = data.Length;
+
+			if (certificate != null)
+				wr.ClientCertificates.Add(certificate);
 
 			using (var rs = wr.GetRequestStream())
 			{

--- a/PushSharp.WindowsPhone/WindowsPhonePushChannelSettings.cs
+++ b/PushSharp.WindowsPhone/WindowsPhonePushChannelSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using PushSharp.Common;
 
@@ -9,13 +10,15 @@ namespace PushSharp.WindowsPhone
 	public class WindowsPhonePushChannelSettings : PushChannelSettings
 	{
 
-		public WindowsPhonePushChannelSettings(byte[] webServiceCertificate = null)
+		public WindowsPhonePushChannelSettings()
 		{
-			this.WebServiceCertificate = webServiceCertificate;
 		}
 
-		public byte[] WebServiceCertificate { get; private set; }
+		public WindowsPhonePushChannelSettings(X509Certificate2 certificate)
+		{
+			this.Certificate = certificate;
+		}
 
-		
+		public X509Certificate2 Certificate { get; private set; }
 	}
 }


### PR DESCRIPTION
I added support to the Windows Phone code to use a client certificate, allowing apps to use unthrottled requests. The settings API changed slightly to take an X509Certificate2 instead of a byte[].
