### PR TITLE
Added WithTimeToLive Method on GcmFluentNotification

### DIFF
--- a/PushSharp.Android/Gcm/GcmFluentNotification.cs
+++ b/PushSharp.Android/Gcm/GcmFluentNotification.cs
@@ -26,6 +26,12 @@ namespace PushSharp
 			return n;
 		}
 
+        public static GcmNotification WithTimeToLive(this GcmNotification n, int ttlSeconds)
+        {
+            n.TimeToLive = ttlSeconds;
+            return n;
+        }
+
 		public static GcmNotification WithJson(this GcmNotification n, string json)
 		{
 			try { var nobj = Newtonsoft.Json.Linq.JObject.Parse(json); }


### PR DESCRIPTION
I have some other changes, so you might want to manually add this in.

Just missing the Fluent method to set the TTL for a notification.
