### PR TITLE
Update WindowsPhoneNotification.cs

### DIFF
--- a/PushSharp.WindowsPhone/WindowsPhoneNotification.cs
+++ b/PushSharp.WindowsPhone/WindowsPhoneNotification.cs
@@ -111,10 +111,10 @@ namespace PushSharp.WindowsPhone
 			var toast = new XElement(wp + "Toast");
 
 			if (!string.IsNullOrEmpty(Text1))
-				toast.Add(new XElement(wp + "Text1", XmlEncode(Text1)));
+				toast.Add(new XElement(wp + "Text1", Text1));
 
 			if (!string.IsNullOrEmpty(Text2))
-				toast.Add(new XElement(wp + "Text2", XmlEncode(Text2)));
+				toast.Add(new XElement(wp + "Text2", Text2));
 
 
 			if (this.OSVersion > WindowsPhoneDeviceOSVersion.Seven)


### PR DESCRIPTION
Made changes to stop the toast notification parameters "Text1" and "Text2" from being double encoded.

The XElement object already makes encoding for any parameter object. When these parameters are also encoded by XmlEncode function this creates a double encoding which causes incorrect text as a notification.
Example problem: 
McDonald's -> McDonald&apos;s (after XmlEncode)-> McDonald&amp;apos;(After XElement constructor). 
