### PR TITLE
Additional GCM nitification fluent method (to notify several devices)

### DIFF
--- a/PushSharp.Android/Gcm/GcmFluentNotification.cs
+++ b/PushSharp.Android/Gcm/GcmFluentNotification.cs
@@ -14,6 +14,12 @@ namespace PushSharp
 			return n;
 		}
 
+        public static GcmNotification ForDeviceRegistrationId(this GcmNotification n, IEnumerable<string> deviceRegistrationIds)
+        {
+            n.RegistrationIds.AddRange(deviceRegistrationIds);
+            return n;
+        }
+
 		public static GcmNotification WithCollapseKey(this GcmNotification n, string collapseKey)
 		{
 			n.CollapseKey = collapseKey;


### PR DESCRIPTION
Usually, you may want to notify several devices in one request. Therefore the fluent method to add several of them would be handy.
