### PR TITLE
Server certificate validation for APNS and GCM

### DIFF
--- a/PushSharp.Android/Gcm/GcmPushChannel.cs
+++ b/PushSharp.Android/Gcm/GcmPushChannel.cs
@@ -22,8 +22,17 @@ namespace PushSharp.Android
 
 		public GcmPushChannel(GcmPushChannelSettings channelSettings)
 		{
-			gcmSettings = channelSettings as GcmPushChannelSettings;	
-		}
+			gcmSettings = channelSettings;
+
+            if (gcmSettings != null && gcmSettings.ValidateServerCertificate)
+            {
+                ServicePointManager.ServerCertificateValidationCallback += ValidateRemoteCertificate;
+            }
+            else
+            {
+                ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, policyErrs) => true; //Don't validate remote cert
+            }
+        }
 
 
 		static GcmPushChannel()
@@ -338,6 +347,11 @@ namespace PushSharp.Android
 				Thread.Sleep(100);
 			}
 		}
+
+        private static bool ValidateRemoteCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors policyErrors)
+        {
+            return policyErrors == SslPolicyErrors.None;
+        }
 
 		class GcmAsyncParameters
 		{

--- a/PushSharp.Android/Gcm/GcmPushChannelSettings.cs
+++ b/PushSharp.Android/Gcm/GcmPushChannelSettings.cs
@@ -14,7 +14,9 @@ namespace PushSharp.Android
 		{
 			this.SenderAuthToken = senderAuthToken;
 			this.GcmUrl = GCM_SEND_URL;
-		}
+
+            this.ValidateServerCertificate = false;
+        }
 
 		public GcmPushChannelSettings(string optionalSenderID, string senderAuthToken, string optionalApplicationIdPackageName)
 		{
@@ -22,11 +24,15 @@ namespace PushSharp.Android
 			this.SenderAuthToken = senderAuthToken;
 			this.ApplicationIdPackageName = optionalApplicationIdPackageName;
 			this.GcmUrl = GCM_SEND_URL;
-		}
+
+            this.ValidateServerCertificate = false;
+        }
 
 		public string SenderID { get; private set; }
 		public string SenderAuthToken { get; private set; }
 		public string ApplicationIdPackageName { get; private set; }
+
+        public bool ValidateServerCertificate { get; set; }
 
 		public string GcmUrl { get; set; }
 

--- a/PushSharp.Apple/ApplePushChannel.cs
+++ b/PushSharp.Apple/ApplePushChannel.cs
@@ -509,9 +509,20 @@ namespace PushSharp.Apple
 			}
 			else
 			{
+                RemoteCertificateValidationCallback userCertificateValidation;
+
+                if (appleSettings != null && appleSettings.ValidateServerCertificate)
+                {
+                    userCertificateValidation = ValidateRemoteCertificate;
+                }
+                else
+                {
+                    userCertificateValidation = (sender, cert, chain, sslPolicyErrors) => true; //Don't validate remote cert
+                } 
+
 				stream = new SslStream(client.GetStream(), false,
-					(sender, cert, chain, sslPolicyErrors) => true, //Don't validate remote cert
-					(sender, targetHost, localCerts, remoteCert, acceptableIssuers) => certificate); //
+                    userCertificateValidation,
+					(sender, targetHost, localCerts, remoteCert, acceptableIssuers) => certificate);
 
 				try
 				{
@@ -535,7 +546,11 @@ namespace PushSharp.Apple
 			//Start reading from the stream asynchronously
 			Reader();
 		}
-		
+
+        private static bool ValidateRemoteCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors policyErrors)
+        {
+            return policyErrors == SslPolicyErrors.None;
+        } 
 	}
 
 	public class SentNotification

--- a/PushSharp.Apple/ApplePushChannelSettings.cs
+++ b/PushSharp.Apple/ApplePushChannelSettings.cs
@@ -73,7 +73,9 @@ namespace PushSharp.Apple
 
 			if (!disableCertificateCheck)	
 				CheckProductionCertificateMatching(production);
-		}
+
+            this.ValidateServerCertificate = false;
+        }
 
 		public bool DetectProduction(X509Certificate2 certificate)
 		{
@@ -188,6 +190,12 @@ namespace PushSharp.Apple
 			get;
 			set;
 		}
+
+        public bool ValidateServerCertificate
+        {
+            get;
+            set;
+        }
 
 		public int ConnectionTimeout { get; set; }
 		public int MaxConnectionAttempts { get; set; }


### PR DESCRIPTION
Added server certificate validation to the ApplePushChannel and
GcmPushChannel classes (default off).

The ApplePushChannelSettings and GcmPushChannelSettings classes define a
boolean flag (ValidateServerCertificate) which is used by the
ApplePushChannel and GcmPushChannel classes (respectively) to determine
whether to validate certificate policy errors or ignore policy errors
for remote server certificates
