### PR TITLE
Close TcpClient in ApplePushChannel prior to reconnecting

### DIFF
--- a/PushSharp.Apple/ApplePushChannel.cs
+++ b/PushSharp.Apple/ApplePushChannel.cs
@@ -455,11 +455,11 @@ namespace PushSharp.Apple
 
 		void connect()
 		{
-            // clean up existing TcpClient
-            if (client != null)
-            {
-                try { client.Close(); } catch {}
-            }
+			// clean up existing TcpClient
+			if (client != null)
+			{
+				try { client.Close(); } catch { }
+			}
 			client = new TcpClient();
 
 			//Notify we are connecting


### PR DESCRIPTION
Suspect our problems in #157 may be due to a resource leak following socket disconnection - the old TcpClient is never explicitly disposed. I've added code to call `Close()` on the TcpClient prior to reconnection.
