### PR TITLE
Resolve issue 244: After the PushSharp lib (v2.1.2) is idle for 5 mins, ...

### DIFF
--- a/PushSharp.Core/PushServiceBase.cs
+++ b/PushSharp.Core/PushServiceBase.cs
@@ -284,7 +284,9 @@ namespace PushSharp.Core
 							Log.Info("{0} -> Destroying Channel", this);
 							ScaleChannels(ChannelScaleAction.Destroy);
 						}
-						while (channels.Count < ServiceSettings.Channels && !this.cancelTokenSource.IsCancellationRequested)
+                        while (channels.Count < ServiceSettings.Channels && !this.cancelTokenSource.IsCancellationRequested
+                            && (DateTime.UtcNow - lastNotificationQueueTime) <= ServiceSettings.IdleTimeout
+                            && Interlocked.Read(ref trackedNotificationCount) > 0)
 						{
 							Log.Info("{0} -> Creating Channel", this);
 							ScaleChannels(ChannelScaleAction.Create);


### PR DESCRIPTION
...the Channel Created and Channel Destroyed events are invoked again and again.

https://github.com/Redth/PushSharp/issues/244
Root cause: After idle timeout, the channel.Cout is zero and the codes
always satisfy the creating channel action. Then idle timeout will
destroy the new created channel and cause the create/destroy cycle.
