### PR TITLE
Added support for passing JToken-derived objects as custom objects

### DIFF
--- a/PushSharp.Apple/AppleNotificationPayload.cs
+++ b/PushSharp.Apple/AppleNotificationPayload.cs
@@ -121,7 +121,10 @@ namespace PushSharp.Apple
 			foreach (string key in this.CustomItems.Keys)
 			{
 				if (this.CustomItems[key].Length == 1)
-					json[key] = new JValue(this.CustomItems[key][0]);
+				{
+					var customItem = this.CustomItems[key][0];
+					json[key] = customItem as JToken ?? new JValue(customItem);
+				}
 				else if (this.CustomItems[key].Length > 1)
 					json[key] = new JArray(this.CustomItems[key]);
 			}


### PR DESCRIPTION
This change would allow consumers to add custom items like so:

    var notif = new AppleNotification()
        .ForDeviceToken(message.Token)
        .WithAlert(message.Text)
        .WithCustomItem("foo", JObject.FromObject(new { One = 1, Two = 2 }));

Currently this would throw an exception. This would provide a workaround to the following issues:

https://github.com/Redth/PushSharp/issues/236
https://github.com/Redth/PushSharp/issues/248
