### PR TITLE
add Safari Push Notifications support.

### DIFF
--- a/PushSharp.Apple/AppleNotificationPayload.cs
+++ b/PushSharp.Apple/AppleNotificationPayload.cs
@@ -64,7 +64,7 @@ namespace PushSharp.Apple
 				this.CustomItems.Add(key, values);
 		}
 
-		public string ToJson()
+		public virtual string ToJson()
 		{
 			JObject json = new JObject();
 
@@ -253,4 +253,40 @@ namespace PushSharp.Apple
 			return ToJson();
 		}
 	}
+
+    public class AppleSafariNotificationPayload : AppleNotificationPayload
+    {
+        public AppleSafariNotificationPayload() { }
+
+        public AppleSafariNotificationPayload(string title, string body, string action = "View", params string[] urlArgs)
+        {
+            this.Title = title;
+            this.Body = body;
+            this.Action = action;
+            this.UrlArgs = urlArgs;
+        }
+
+        public override string ToJson()
+        {
+            var json = new JObject();
+            var aps = new JObject();
+            var alert = new JObject();
+
+            alert["title"] = new JValue(this.Title);
+            alert["body"] = new JValue(this.Body);
+            alert["action"] = new JValue(this.Action);
+
+            aps["alert"] = alert;
+            aps["url-args"] = new JArray(this.UrlArgs);
+
+            json["aps"] = aps;
+
+            return json.ToString(Newtonsoft.Json.Formatting.None, null);
+        }
+
+        public string Title { get; set; }
+        public string Body { get; set; }
+        public string Action { get; set; }
+        public string[] UrlArgs { get; set; }
+    }
 }

--- a/PushSharp.Apple/ApplePushChannelSettings.cs
+++ b/PushSharp.Apple/ApplePushChannelSettings.cs
@@ -85,7 +85,7 @@ namespace PushSharp.Apple
 			{
 				var subjectName = certificate.SubjectName.Name;
 
-				if (subjectName.Contains("Apple Production IOS Push Services"))
+				if (subjectName.Contains("Apple Production IOS Push Services") || subjectName.Contains("Website Push ID"))
 					production = true;
 			}
 			
@@ -102,7 +102,7 @@ namespace PushSharp.Apple
 				if (!issuerName.Contains("Apple"))
 					throw new ArgumentException("Your Certificate does not appear to be issued by Apple!  Please check to ensure you have the correct certificate!");
 
-				if (production && !subjectName.Contains("Apple Production IOS Push Services"))
+				if (production && !subjectName.Contains("Apple Production IOS Push Services") && !subjectName.Contains("Website Push ID"))
 					throw new ArgumentException("You have selected the Production server, yet your Certificate does not appear to be the Production certificate!  Please check to ensure you have the correct certificate!");
 
 

--- a/PushSharp.Sample/Program.cs
+++ b/PushSharp.Sample/Program.cs
@@ -33,7 +33,7 @@ namespace PushSharp.Sample
 			push.OnDeviceSubscriptionChanged += DeviceSubscriptionChanged;
 			push.OnChannelCreated += ChannelCreated;
 			push.OnChannelDestroyed += ChannelDestroyed;
-			
+
 
 			//------------------------------------------------
 			//IMPORTANT NOTE about Push Service Registrations
@@ -70,6 +70,15 @@ namespace PushSharp.Sample
 			                           .WithAlert("Hello World!")
 			                           .WithBadge(7)
 			                           .WithSound("sound.caf"));
+
+            //-------------------------
+            // SAFARI NOTIFICATIONS
+            //-------------------------
+            /* For Safari push notification, use AppleSafariNotificatioPayload instead.
+            push.QueueNotification(new AppleNotification()
+                                       .ForDeviceToken("DEVICE TOKEN HERE")
+                                       .WithPayload(new AppleSafariNotificationPayload("This is Title", "This is Body", "View", "arg0", "arg1")));
+            //*/
 
 			
 			//---------------------------


### PR DESCRIPTION
Here are the changes to support Safari Push Notifications:
* add `AppleSafariNotificationPayload` class which inherits `AppleNotificationPayload`.
* change `AppleNotificationPayload.ToJson()` method as virtual.
* add new rules to `ApplePushChannelSettings.DetectProduction()` and `ApplePushChannelSettings.CheckProductionCertificateMatching()`.
* add Safari Push Notification sample code to `PushSharp.Sample` project.