### PR TITLE
BUG Fix for Apple Silent Push Notifications

### DIFF
--- a/PushSharp.Apple/AppleNotificationPayload.cs
+++ b/PushSharp.Apple/AppleNotificationPayload.cs
@@ -112,7 +112,7 @@ namespace PushSharp.Apple
 			if (!string.IsNullOrEmpty(this.Sound))
 				aps["sound"] = new JValue(this.Sound);
 
-            if (this.ContentAvailable.HasValue
+            if (this.ContentAvailable.HasValue)
             {
                 aps["content-available"] = new JValue(this.ContentAvailable.Value);
                 if (string.IsNullOrEmpty(this.Sound))


### PR DESCRIPTION
Adding support for silent push notifications. Adding an empty sound entry when non is set to make the payload valid.
