### PR TITLE
Fixed PushServiceBase.Stop infinitely sleeping

### DIFF
--- a/PushSharp.Apple/ApplePushService.cs
+++ b/PushSharp.Apple/ApplePushService.cs
@@ -12,7 +12,6 @@ namespace PushSharp.Apple
 	public class ApplePushService : PushServiceBase
 	{
 		FeedbackService feedbackService;
-		CancellationTokenSource cancelTokenSource;
 		Timer timerFeedback = null;
 		
 		
@@ -35,7 +34,6 @@ namespace PushSharp.Apple
 			: base(pushChannelFactory ?? new ApplePushChannelFactory(), channelSettings, serviceSettings)
 		{
 			var appleChannelSettings = channelSettings;
-			cancelTokenSource = new CancellationTokenSource();
 
 			//allow control over feedback call interval, if set to zero, don't make feedback calls automatically
 			if (appleChannelSettings.FeedbackIntervalMinutes > 0)
@@ -69,6 +67,15 @@ namespace PushSharp.Apple
 		{
 			get { return false; }
 		}
+
+        public override void Stop(bool waitForQueueToFinish = true)
+        {
+            base.Stop(waitForQueueToFinish);
+
+            //Stop the timer for feedback
+            if (this.timerFeedback != null)
+                this.timerFeedback.Change(Timeout.Infinite, Timeout.Infinite);
+        }
 	}
 
 	public class ApplePushChannelFactory : IPushChannelFactory

--- a/PushSharp.Core/PushServiceBase.cs
+++ b/PushSharp.Core/PushServiceBase.cs
@@ -63,7 +63,7 @@ namespace PushSharp.Core
 		volatile bool stopping;
 		List<ChannelWorker> channels = new List<ChannelWorker>();
 		NotificationQueue queuedNotifications;
-		CancellationTokenSource cancelTokenSource = new CancellationTokenSource();
+	    protected CancellationTokenSource cancelTokenSource = new CancellationTokenSource();
 		List<WaitTimeMeasurement> measurements = new List<WaitTimeMeasurement>();
         List<WaitTimeMeasurement> sendTimeMeasurements = new List<WaitTimeMeasurement>();
 		DateTime lastNotificationQueueTime = DateTime.MinValue;
@@ -110,8 +110,6 @@ namespace PushSharp.Core
 		{
 			lastNotificationQueueTime = DateTime.UtcNow;
 
-			Interlocked.Increment(ref trackedNotificationCount);
-
 			//Measure when the message entered the queue
 			notification.EnqueuedTimestamp = DateTime.UtcNow;
 
@@ -121,6 +119,9 @@ namespace PushSharp.Core
 			if (this.ServiceSettings.MaxNotificationRequeues < 0 ||
 			    notification.QueuedCount <= this.ServiceSettings.MaxNotificationRequeues)
 			{
+                // only increment the tracking counter if the notification still has retries left
+                Interlocked.Increment(ref trackedNotificationCount);
+
 				//Reset the Enqueued time in case this is a requeue
 				notification.EnqueuedTimestamp = DateTime.UtcNow;
 
@@ -146,7 +147,7 @@ namespace PushSharp.Core
 			}
 		}
 
-		public void Stop(bool waitForQueueToFinish = true)
+		public virtual void Stop(bool waitForQueueToFinish = true)
 		{
 			stopping = true;
 			var started = DateTime.UtcNow;


### PR DESCRIPTION
Modified the PushServiceBase.QueueNotification method to only increment
the trackedNotificationCounter when a notification is actually queued,
as a MaxSendAttemptsReached failure scenario was NOT decrementing this
counter - causing the PushServiceBase.Stop method to sleep infinitely
when waitForQueueToFinish is true. Also modified the ApplePushService
class to implement Stop and clean up the Feedback timer task (which will
continuously run in the above bug scenario) when the base Stop method
completes execution
