### PR TITLE
Allow Custom Json String when push to Apple.

### DIFF
--- a/PushSharp.Apple/AppleNotificationPayload.cs
+++ b/PushSharp.Apple/AppleNotificationPayload.cs
@@ -27,6 +27,11 @@ namespace PushSharp.Apple
 			private set;
 		}
 
+        /// <summary>
+        /// use this will replace this.CustomItems
+        /// </summary>
+        public string CustomJson { get; set; }
+
 		public AppleNotificationPayload()
 		{
 			HideActionButton = false;
@@ -118,13 +123,24 @@ namespace PushSharp.Apple
 			if (aps.Count > 0)
 				json["aps"] = aps;
 
-			foreach (string key in this.CustomItems.Keys)
-			{
-				if (this.CustomItems[key].Length == 1)
-					json[key] = new JValue(this.CustomItems[key][0]);
-				else if (this.CustomItems[key].Length > 1)
-					json[key] = new JArray(this.CustomItems[key]);
-			}
+            if (string.IsNullOrEmpty(this.CustomJson))
+            {
+                foreach (string key in this.CustomItems.Keys)
+                {
+                    if (this.CustomItems[key].Length == 1)
+                        json[key] = new JValue(this.CustomItems[key][0]);
+                    else if (this.CustomItems[key].Length > 1)
+                        json[key] = new JArray(this.CustomItems[key]);
+                }
+            }
+            else
+            {
+                var obj = (JObject)Newtonsoft.Json.JsonConvert.DeserializeObject(this.CustomJson);
+                foreach (KeyValuePair<string,JToken> kv in obj)
+                {
+                    json[kv.Key] = kv.Value;
+                }
+            }
 
 			string rawString = json.ToString(Newtonsoft.Json.Formatting.None, null);
 

--- a/PushSharp.Apple/ApplePushChannel.cs
+++ b/PushSharp.Apple/ApplePushChannel.cs
@@ -536,7 +536,7 @@ namespace PushSharp.Apple
 
 				try
 				{
-					stream.AuthenticateAsClient(this.appleSettings.Host, this.certificates, System.Security.Authentication.SslProtocols.Ssl3, false);
+					stream.AuthenticateAsClient(this.appleSettings.Host, this.certificates, System.Security.Authentication.SslProtocols.Tls, false);
 					//stream.AuthenticateAsClient(this.appleSettings.Host);
 				}
 				catch (System.Security.Authentication.AuthenticationException ex)

--- a/PushSharp.Apple/FeedbackService.cs
+++ b/PushSharp.Apple/FeedbackService.cs
@@ -63,7 +63,7 @@ namespace PushSharp.Apple
 				(sender, cert, chain, sslErrs) => { return true; },
 				(sender, targetHost, localCerts, remoteCert, acceptableIssuers) => { return certificate; });
 
-			stream.AuthenticateAsClient(settings.FeedbackHost, certificates, System.Security.Authentication.SslProtocols.Ssl3, false);
+			stream.AuthenticateAsClient(settings.FeedbackHost, certificates, System.Security.Authentication.SslProtocols.Tls, false);
 
 
 			//Set up


### PR DESCRIPTION
In some case we want to use String insead of Object to send custom notification.
This commit can merge CustomJson into json object instead of CustomItems when CustomJson
is not null.