### PR TITLE
The broker tries to look for a named appid before the registration actua...

### DIFF
--- a/PushSharp.Core/PushBroker.cs
+++ b/PushSharp.Core/PushBroker.cs
@@ -148,7 +148,8 @@ namespace PushSharp
 				lock (serviceRegistrationsLock)
 				{
 					return from sr in serviceRegistrations 
-					   where sr.ApplicationId.Equals (applicationId) 
+					   where !string.IsNullOrEmpty(sr.ApplicationId)
+						&& sr.ApplicationId.Equals (applicationId) 
 						&& sr.NotificationType == type
 					   select sr.Service;
 				}


### PR DESCRIPTION
...lly occurs, which causes

a null exception. Adding a quick check for null/empty string to ensure this doesn't happen.
