### PR TITLE
Include OldSubscriptionId and SubscriptionExpiryUtc in notification result for expired Windows and Windows Phone subscriptions

### DIFF
--- a/PushSharp.Windows/WindowsPushChannel.cs
+++ b/PushSharp.Windows/WindowsPushChannel.cs
@@ -243,11 +243,19 @@ namespace PushSharp.Windows
 				callback(this, new SendNotificationResult(status.Notification));
 				return;
 			}
-			else if (status.HttpStatus == HttpStatusCode.NotFound || status.HttpStatus == HttpStatusCode.Gone) //404 or 410
+			
+			if (status.HttpStatus == HttpStatusCode.NotFound || status.HttpStatus == HttpStatusCode.Gone) //404 or 410
 			{
-				callback(this, new SendNotificationResult(status.Notification, false, new Exception("Device Subscription Expired")) { IsSubscriptionExpired = true });
+				callback(this, new SendNotificationResult(status.Notification, false, new Exception("Device Subscription Expired"))
+				{
+					IsSubscriptionExpired = true,
+					OldSubscriptionId = status.Notification.ChannelUri,
+					SubscriptionExpiryUtc = DateTime.UtcNow
+				});
+
+				return;
 			}
-				
+
 			callback(this, new SendNotificationResult(status.Notification, false, new WindowsNotificationSendFailureException(status)));
 		}
 

--- a/PushSharp.WindowsPhone/WindowsPhonePushChannel.cs
+++ b/PushSharp.WindowsPhone/WindowsPhonePushChannel.cs
@@ -165,11 +165,18 @@ namespace PushSharp.WindowsPhone
 		}
 		
 		void HandleStatus(SendNotificationCallbackDelegate callback, WindowsPhoneMessageStatus status, WindowsPhoneNotification notification = null)
-		{	
+		{
+			if (callback == null)
+				return;
+
 			if (status.SubscriptionStatus == WPSubscriptionStatus.Expired)
 			{
-				if (callback != null)
-					callback(this, new SendNotificationResult(notification, false, new Exception("Device Subscription Expired")) { IsSubscriptionExpired = true });
+				callback(this, new SendNotificationResult(notification, false, new Exception("Device Subscription Expired"))
+				{
+					IsSubscriptionExpired = true,
+					OldSubscriptionId = notification != null ? notification.EndPointUrl : null,
+					SubscriptionExpiryUtc = DateTime.UtcNow
+				});
 
 				return;
 			}
@@ -177,13 +184,12 @@ namespace PushSharp.WindowsPhone
 			if (status.HttpStatus == HttpStatusCode.OK
 				&& status.NotificationStatus == WPNotificationStatus.Received)
 			{
-				if (callback != null)
-					callback(this, new SendNotificationResult(notification));
+				callback(this, new SendNotificationResult(notification));
+
 				return;
 			}
 
-			if (callback != null)
-				callback(this, new SendNotificationResult(status.Notification, false, new WindowsPhoneNotificationSendFailureException(status)));
+			callback(this, new SendNotificationResult(status.Notification, false, new WindowsPhoneNotificationSendFailureException(status)));
 		}
 
 		public void Dispose()


### PR DESCRIPTION
This patch adds the channelUri/EndpointUrl to subscription expired notifications for Windows and Windows Phone.
