### PR TITLE
Added programmatic web proxy configuration for GCM

### DIFF
--- a/PushSharp.Android/Gcm/GcmPushChannel.cs
+++ b/PushSharp.Android/Gcm/GcmPushChannel.cs
@@ -51,6 +51,7 @@ namespace PushSharp.Android
 			//var postData = msg.GetJson();
 
 			var webReq = (HttpWebRequest)WebRequest.Create(gcmSettings.GcmUrl);
+			ConfigureProxy (webReq);
 			//webReq.ContentLength = postData.Length;
 			webReq.Method = "POST";
 			webReq.ContentType = "application/json";
@@ -68,6 +69,14 @@ namespace PushSharp.Android
 				SenderId = gcmSettings.SenderID,
 				ApplicationId = gcmSettings.ApplicationIdPackageName
 			});
+		}
+
+		void ConfigureProxy(HttpWebRequest request)
+		{
+			if (gcmSettings.Proxy != null)
+			{
+				request.Proxy = gcmSettings.Proxy;
+			}
 		}
 
 		void requestStreamCallback(IAsyncResult result)

--- a/PushSharp.Android/Gcm/GcmPushChannelSettings.cs
+++ b/PushSharp.Android/Gcm/GcmPushChannelSettings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using PushSharp.Core;
+using System.Net;
 
 namespace PushSharp.Android
 {
@@ -31,6 +32,7 @@ namespace PushSharp.Android
 		public string SenderID { get; private set; }
 		public string SenderAuthToken { get; private set; }
 		public string ApplicationIdPackageName { get; private set; }
+		public WebProxy Proxy { get; set; }
 
         public bool ValidateServerCertificate { get; set; }
 


### PR DESCRIPTION
Didn’t know how applicable this was for all push types (not all are
HTTP I believe?), so I kept it specific to GCM.

Would love thoughts, thanks!