### PR TITLE
Remove nasty stuff in AppDelegate in sample

### DIFF
--- a/Client.Samples/PushSharp.ClientSample.MonoTouch/PushSharp.ClientSample.MonoTouch/AppDelegate.cs
+++ b/Client.Samples/PushSharp.ClientSample.MonoTouch/PushSharp.ClientSample.MonoTouch/AppDelegate.cs
@@ -48,13 +48,9 @@ namespace PushSharp.ClientSample.AppleMonoTouch
 		public override void RegisteredForRemoteNotifications (UIApplication application, NSData deviceToken)
 		{
 			var oldDeviceToken = NSUserDefaults.StandardUserDefaults.StringForKey("PushDeviceToken");
-
-			//There's probably a better way to do this
-		  	var strFormat = new NSString("%@");
-		  	var dt = new NSString(MonoTouch.ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr(new MonoTouch.ObjCRuntime.Class("NSString").Handle, new MonoTouch.ObjCRuntime.Selector("stringWithFormat:").Handle, strFormat.Handle, deviceToken.Handle));
-			var newDeviceToken = dt.ToString().Replace("<", "").Replace(">", "").Replace(" ", "");
-
-			if (string.IsNullOrEmpty(oldDeviceToken) || !deviceToken.Equals(newDeviceToken))
+			var newDeviceToken = deviceToken.ToString().Replace("<", "").Replace(">", "").Replace(" ", "");
+			
+			if (string.IsNullOrEmpty(oldDeviceToken) || !oldDeviceToken.Equals(newDeviceToken))
 			{
 				//TODO: Put your own logic here to notify your server that the device token has changed/been created!
 			}


### PR DESCRIPTION
Please don't encourage usage of that nasty piece of code in the `RegisteredForRemoteNotifications` in the iOS sample. We can just use `ToString()` to get the token :) 
