### PR TITLE
Typo in Sample project

### DIFF
--- a/PushSharp.Sample/Program.cs
+++ b/PushSharp.Sample/Program.cs
@@ -147,7 +147,7 @@ namespace PushSharp.Sample
 
 		static void ServiceException(object sender, Exception exception)
 		{
-            Console.WriteLine("Service Exception: " + sender + " -> " + exception);
+			Console.WriteLine("Service Exception: " + sender + " -> " + exception);
 		}
 
 		static void DeviceSubscriptionExpired(object sender, string expiredDeviceSubscriptionId, DateTime timestamp, INotification notification)


### PR DESCRIPTION
Typo (Channel => Service) in PushSharp.Sample/Program.cs has been fixed :)
