### PR TITLE
AppleNotification - Increased Max Payload Size.

### DIFF
--- a/PushSharp.Apple/AppleNotification.cs
+++ b/PushSharp.Apple/AppleNotification.cs
@@ -45,8 +45,14 @@ namespace PushSharp.Apple
 		public DateTime? Expiration { get; set; }
 		public const int DEVICE_TOKEN_BINARY_SIZE = 32;
 		public const int DEVICE_TOKEN_STRING_SIZE = 64;
-		public const int MAX_PAYLOAD_SIZE = 256;
-		public static readonly DateTime DoNotStore = DateTime.MinValue;
+
+        // public const int MAX_PAYLOAD_SIZE = 256;
+
+        // Max Payload Size increased to 2048 bytes (2K) after iOS8 Launch.
+        // Since it's a server upgrade, this will also affects all previous iOS versions.
+        public const int MAX_PAYLOAD_SIZE = 2048; 
+        
+        public static readonly DateTime DoNotStore = DateTime.MinValue;
 		private static readonly DateTime UNIX_EPOCH = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
 		public AppleNotification()


### PR DESCRIPTION
Apple recently increased Max Payload Size from 256 to 2048 bytes (2K) on both sandbox and production APN servers. Since it's a server upgrade, this change will also affects all previous iOS versions. I changed the MAX_PAYLOAD_SIZE accordingly. I recommend doing so because the library internally check payload size, raising a NotificationFailureException if it's lesser than MAX_PAYLOAD_SIZE const and thus preventing any notification greater than 256 bytes to be sent.
