### PR TITLE
GCM - Handing GCM HTTP Errors

### DIFF
--- a/PushSharp.Android/Gcm/GcmPushChannel.cs
+++ b/PushSharp.Android/Gcm/GcmPushChannel.cs
@@ -320,8 +320,16 @@ namespace PushSharp.Android
 						}
 					}
 
-					//503 exponential backoff, get retry-after header
-					result.ResponseCode = GcmMessageTransportResponseCode.ServiceUnavailable;
+                    //Compatability for apps written with previous versions of PushSharp. 
+                    if (asyncParam.WebResponse.StatusCode == HttpStatusCode.InternalServerError)
+                    {
+                        result.ResponseCode = GcmMessageTransportResponseCode.InternalServiceError;
+                    }
+                    else
+                    {
+                        //503 exponential backoff, get retry-after header
+                        result.ResponseCode = GcmMessageTransportResponseCode.ServiceUnavailable;
+                    }
 
 					throw new GcmServiceUnavailableTransportException(retryAfter, result);
 				}


### PR DESCRIPTION
Changed code so all 500 errors throw a GCMServiceUnavailableTransportExcpetion, as according to the docs they should be handled the same way.

_Errors in the 500-599 range (such as 500 or 503) indicate that there wa an internal error in the GCM server while trying to process the request, or that the server is temporarily unavailable (for example, because of timeouts). Sender must retry later, honoring any Retry-Afterheader included in the response. Application servers must implement exponential back-off.Troubleshoot_

https://developer.android.com/google/gcm/http.html
