### PR TITLE
Don't try to convert JObject/JArray to JValue and then to JToken

### DIFF
--- a/PushSharp.Apple/AppleNotificationPayload.cs
+++ b/PushSharp.Apple/AppleNotificationPayload.cs
@@ -128,7 +128,10 @@ namespace PushSharp.Apple
 			foreach (string key in this.CustomItems.Keys)
 			{
 				if (this.CustomItems[key].Length == 1)
-					json[key] = new JValue(this.CustomItems[key][0]);
+				{
+					object custom = this.CustomItems[key][0];
+					json[key] = custom is JToken ? (JToken) custom : new JValue(custom);
+				}
 				else if (this.CustomItems[key].Length > 1)
 					json[key] = new JArray(this.CustomItems[key]);
 			}


### PR DESCRIPTION
If someone tries to pass JObject as extra data (which should be valid since Apple allows it), the current implementation fails to treat it as JToken.
