### PR TITLE
Resolving an issue with PushBroker EventHandlers not being called before StopAllServices completes.

### DIFF
--- a/NuGet/PushSharp.nuspec
+++ b/NuGet/PushSharp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
     <metadata>
         <id>PushSharp</id>
-        <version>2.2.1.0</version>
+        <version>2.2.1.3</version>
         <title>PushSharp</title>
         <authors>Redth</authors>
         <owners>Redth</owners>
@@ -12,7 +12,9 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>A server-side library for sending Push Notifications to iOS (iPhone/iPad APNS &amp; PassKit), Mac OSX (Mountain Lion+), Android (GCM/C2DM), Chrome (GCM), Windows Phone 7/8, Windows 8, Blackberry, Amazon Device Messaging, and Firefox OS</description>
         <summary>A server-side library for sending Push Notifications to iOS (iPhone/iPad APNS &amp; PassKit), Mac OSX, Android (GCM/C2DM), Chrome (GCM) Windows Phone 7/8, Windows 8, Blackberry, Amazon (ADM)</summary>
-        <releaseNotes>2.2.0 - iOS8 Compatibility, APNS Server changes, bugfixes
+        <releaseNotes>2.2.1.3 - Add support for APN Alert Title field in iOS 8.1 
+
+2.2.0 - iOS8 Compatibility, APNS Server changes, bugfixes
 
 2.1.2 - Bugfixes, APNS Stability Improvements, APNS Node.js Mock Server, PushBroker Start/Register services per applicationId now possible
 

--- a/PushSharp.Android/Gcm/GcmPushChannel.cs
+++ b/PushSharp.Android/Gcm/GcmPushChannel.cs
@@ -43,6 +43,8 @@ namespace PushSharp.Android
 		
 		public void SendNotification(INotification notification, SendNotificationCallbackDelegate callback)
 		{
+            Interlocked.Increment(ref waitCounter);
+
 			var msg = notification as GcmNotification;
 
 			var result = new GcmMessageTransportResponse();

--- a/PushSharp.Apple/AppleNotificationAlert.cs
+++ b/PushSharp.Apple/AppleNotificationAlert.cs
@@ -94,8 +94,9 @@ namespace PushSharp.Apple
 				if (!string.IsNullOrEmpty(Body)
 					|| !string.IsNullOrEmpty(ActionLocalizedKey)
 					|| !string.IsNullOrEmpty(LocalizedKey)
-					|| (LocalizedArgs != null && LocalizedArgs.Count > 0)
+                    || (LocalizedArgs != null && LocalizedArgs.Count > 0)
                     || !string.IsNullOrEmpty(LaunchImage)
+                    || !string.IsNullOrEmpty(Title)
                     )
 					return false;
 				else
@@ -108,8 +109,9 @@ namespace PushSharp.Apple
 	        return !string.IsNullOrEmpty(Body)
 	               && string.IsNullOrEmpty(LocalizedKey)
 	               && string.IsNullOrEmpty(ActionLocalizedKey)
-	               && (LocalizedArgs == null || LocalizedArgs.Count <= 0)
-	               && string.IsNullOrEmpty(LaunchImage)
+                   && (LocalizedArgs == null || LocalizedArgs.Count <= 0)
+                   && string.IsNullOrEmpty(LaunchImage)
+                   && string.IsNullOrEmpty(Title)
                    && !hideActionButton;
 	    }
 	}

--- a/PushSharp.Apple/AppleNotificationAlert.cs
+++ b/PushSharp.Apple/AppleNotificationAlert.cs
@@ -22,6 +22,16 @@ namespace PushSharp.Apple
 			LocalizedArgs = new List<object>();
             LaunchImage = null;
 		}
+        
+        /// <summary>
+        /// Title of the Notification's Alert
+        /// </summary>
+        /// <remarks>Added in iOS 8.2</remarks>
+        public string Title
+        {
+            get;
+            set;
+        }
 
 		/// <summary>
 		/// Body Text of the Notification's Alert
@@ -92,5 +102,15 @@ namespace PushSharp.Apple
 					return true;
 			}
 		}
+
+        public bool ShouldSerializeAsString(bool hideActionButton)
+	    {
+	        return !string.IsNullOrEmpty(Body)
+	               && string.IsNullOrEmpty(LocalizedKey)
+	               && string.IsNullOrEmpty(ActionLocalizedKey)
+	               && (LocalizedArgs == null || LocalizedArgs.Count <= 0)
+	               && string.IsNullOrEmpty(LaunchImage)
+                   && !hideActionButton;
+	    }
 	}
 }

--- a/PushSharp.Apple/AppleNotificationPayload.cs
+++ b/PushSharp.Apple/AppleNotificationPayload.cs
@@ -80,18 +80,16 @@ namespace PushSharp.Apple
 
 			if (!this.Alert.IsEmpty)
 			{
-                if (!string.IsNullOrEmpty(this.Alert.Body)
-					&& string.IsNullOrEmpty(this.Alert.LocalizedKey)
-					&& string.IsNullOrEmpty(this.Alert.ActionLocalizedKey)
-					&& (this.Alert.LocalizedArgs == null || this.Alert.LocalizedArgs.Count <= 0)
-					&& string.IsNullOrEmpty(this.Alert.LaunchImage)
-                    && !this.HideActionButton)
+                if (this.Alert.ShouldSerializeAsString(this.HideActionButton))
 				{
 					aps["alert"] = new JValue(this.Alert.Body);
 				}
 				else
 				{
 					JObject jsonAlert = new JObject();
+
+                    if (!string.IsNullOrEmpty(this.Alert.Title))
+                        jsonAlert["title"] = new JValue(this.Alert.Title);
 
 					if (!string.IsNullOrEmpty(this.Alert.LocalizedKey))
 						jsonAlert["loc-key"] = new JValue(this.Alert.LocalizedKey);

--- a/PushSharp.Core/AssemblyVersionInfo.cs
+++ b/PushSharp.Core/AssemblyVersionInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.1.0")]
-[assembly: AssemblyFileVersion("2.2.1.0")]
+[assembly: AssemblyVersion("2.2.1.3")]
+[assembly: AssemblyFileVersion("2.2.1.3")]

--- a/PushSharp.Core/PushServiceBase.cs
+++ b/PushSharp.Core/PushServiceBase.cs
@@ -592,6 +592,13 @@ namespace PushSharp.Core
 			public void Dispose()
 			{
 				CancelTokenSource.Cancel();
+                
+                var slept = 0;
+                while (!this.WorkerTask.IsCompleted && slept <= 5000)
+                {
+                    slept += 100;
+                    Thread.Sleep(100);
+                }
 			}
 
             public string Id { get; private set; }


### PR DESCRIPTION
Hi Redth,

I was having an issue where I was missing NotificationSend events when the PushBroker's StopAllServices method was called. The last few callbacks wern't activated before the channels were disposed and EventHandlers disconnected from the PushBroker.

This change will prevent the PushServiceBase from completing it's dispose method until the Channel has completed processing of any notifications.

There's also a minor fix for GcmPushChannel where the waitCounter was being used to block before exiting Dispose but was never incremented to begin with.
