### PR TITLE
updated documentation and program.cs to include missing properties

### DIFF
--- a/PushSharp.Sample/Program.cs
+++ b/PushSharp.Sample/Program.cs
@@ -83,7 +83,7 @@ namespace PushSharp.Sample
 			//Fluent construction of an Android GCM Notification
 			//IMPORTANT: For Android you MUST use your own RegistrationId here that gets generated within your Android app itself!
 			push.QueueNotification(new GcmNotification().ForDeviceRegistrationId("DEVICE REGISTRATION ID HERE")
-			                      .WithJson("{\"alert\":\"Hello World!\",\"badge\":7,\"sound\":\"sound.caf\"}"));
+			                      .WithJson(@"{""alert"":""This is the future"",""badge"":7,""sound"":""sound.caf"",""title"":""Status Bar title"",""message"":""Some text you want to display to the user""}"));
 			
 
 			//-----------------------------

--- a/README.md
+++ b/README.md
@@ -81,11 +81,13 @@ push.RegisterGcmService(new GcmPushChannelSettings("theauthorizationtokenhere"))
 //Fluent construction of an Android GCM Notification
 //IMPORTANT: For Android you MUST use your own RegistrationId here that gets generated within your Android app itself!
 push.QueueNotification(new GcmNotification().ForDeviceRegistrationId("DEVICE REGISTRATION ID HERE")
-                      .WithJson("{\"alert\":\"Hello World!\",\"badge\":7,\"sound\":\"sound.caf\"}"));
+                      .WithJson(@"{""alert"":""This is the future"",""badge"":7,""sound"":""sound.caf"",""title"":""Status Bar title"",""message"":""Some text you want to display to the user""}"));
 
 ```	
 
 Please see the PushSharp.Sample project for a more thorough example!
+
+// UPDATE: For those using cordova 3+ You need to include the properties "title" and "message" in the .WithJson() method above or the notification will not be handled on android.
 
 ********************
 


### PR DESCRIPTION
The notification aren't handled by cordova applications unless the title and message properties are included in the QueueNotification extension .WithJson().

If omitted, the push notification is never rendered in the status bar. and will only raise the event whilst the application is in the active state.