### PR TITLE
Make it possible to send an APN without sound

### DIFF
--- a/PushSharp.Apple/AppleNotificationPayload.cs
+++ b/PushSharp.Apple/AppleNotificationPayload.cs
@@ -123,11 +123,6 @@ namespace PushSharp.Apple
             if (this.ContentAvailable.HasValue)
             {
                 aps["content-available"] = new JValue(this.ContentAvailable.Value);
-                if (string.IsNullOrEmpty(this.Sound))
-                {
-                    //You need to add an empty string for sound or the payload is not sent
-                    aps["sound"] = new JValue("");
-                }
             }
 
 			if (!string.IsNullOrEmpty(this.Category))


### PR DESCRIPTION
Correct me if I'm wrong, but it is possible to send a payload without an
empty sound string, but if it's included, then the device plays sound
anyways, whereas it doesn't when there's no sound property at all.
http://stackoverflow.com/a/9841653 seems to confirm it.