### PR TITLE
fixed duplicate registration error message

### DIFF
--- a/PushSharp.Core/PushBroker.cs
+++ b/PushSharp.Core/PushBroker.cs
@@ -38,7 +38,7 @@ namespace PushSharp
 		public void RegisterService<TPushNotification>(IPushService pushService, string applicationId, bool raiseErrorOnDuplicateRegistrations = true) where TPushNotification : Notification
 		{
 			if (raiseErrorOnDuplicateRegistrations && GetRegistrations<TPushNotification> (applicationId).Any ())
-				throw new InvalidOperationException ("There's already a service registered to handle " + typeof(TPushNotification).Name + " notification types for the Application Id: " + (applicationId ?? "[ANY].  If you want to register the service anyway, pass in the raiseErrorOnDuplicateRegistrations=true parameter to this method."));
+				throw new InvalidOperationException ("There's already a service registered to handle " + typeof(TPushNotification).Name + " notification types for the Application Id: " + (applicationId ?? "[ANY].  If you want to register the service anyway, pass in the raiseErrorOnDuplicateRegistrations=false parameter to this method."));
 
 			var registration = ServiceRegistration.Create<TPushNotification> (pushService, applicationId);
 


### PR DESCRIPTION
This is a quick fix to prevent confusing users, but there is a larger problem that should be fixed: If a client registers and then goes down (for example because the registration response does not arrive due to a network error), when the client retries registration, by default, it fails because the previous registration hasn't timed out. This default can be overridden by setting raiseErrorOnDuplicateRegistrations=false. However, this default seems backwards. Additionally, having to deviate from the default means you can't use extension methods like RegisterGcmService.