### PR TITLE
Added support for Title property of Apple Notification Alert

### DIFF
--- a/PushSharp.Apple/AppleNotificationAlert.cs
+++ b/PushSharp.Apple/AppleNotificationAlert.cs
@@ -23,6 +23,15 @@ namespace PushSharp.Apple
             LaunchImage = null;
 		}
 
+        /// <summary>
+        /// Title Text of the Notification's Alert
+        /// </summary>
+        public string Title
+        {
+            get;
+            set;
+        }
+
 		/// <summary>
 		/// Body Text of the Notification's Alert
 		/// </summary>
@@ -81,7 +90,8 @@ namespace PushSharp.Apple
 		{
 			get
 			{
-				if (!string.IsNullOrEmpty(Body)
+				if (!string.IsNullOrEmpty(Title)
+                    || !string.IsNullOrEmpty(Body)
 					|| !string.IsNullOrEmpty(ActionLocalizedKey)
 					|| !string.IsNullOrEmpty(LocalizedKey)
 					|| (LocalizedArgs != null && LocalizedArgs.Count > 0)

--- a/PushSharp.Apple/AppleNotificationAlert.cs
+++ b/PushSharp.Apple/AppleNotificationAlert.cs
@@ -16,6 +16,7 @@ namespace PushSharp.Apple
 		/// </summary>
 		public AppleNotificationAlert()
 		{
+            Title = null;
 			Body = null;
 			ActionLocalizedKey = null;
 			LocalizedKey = null;

--- a/PushSharp.Apple/AppleNotificationPayload.cs
+++ b/PushSharp.Apple/AppleNotificationPayload.cs
@@ -81,6 +81,7 @@ namespace PushSharp.Apple
 			if (!this.Alert.IsEmpty)
 			{
                 if (!string.IsNullOrEmpty(this.Alert.Body)
+                    && string.IsNullOrEmpty(this.Alert.Title)
 					&& string.IsNullOrEmpty(this.Alert.LocalizedKey)
 					&& string.IsNullOrEmpty(this.Alert.ActionLocalizedKey)
 					&& (this.Alert.LocalizedArgs == null || this.Alert.LocalizedArgs.Count <= 0)
@@ -99,11 +100,15 @@ namespace PushSharp.Apple
 					if (this.Alert.LocalizedArgs != null && this.Alert.LocalizedArgs.Count > 0)
 						jsonAlert["loc-args"] = new JArray(this.Alert.LocalizedArgs.ToArray());
 
-					if (!string.IsNullOrEmpty(this.Alert.Body))
+                    if (!string.IsNullOrEmpty(this.Alert.Title))
+                        jsonAlert["title"] = new JValue(this.Alert.Title);
+
+                    if (!string.IsNullOrEmpty(this.Alert.Body))
 						jsonAlert["body"] = new JValue(this.Alert.Body);
 
 					if (this.HideActionButton)
 						jsonAlert["action-loc-key"] = new JValue((string)null);
+
 					else if (!string.IsNullOrEmpty(this.Alert.ActionLocalizedKey))
 						jsonAlert["action-loc-key"] = new JValue(this.Alert.ActionLocalizedKey);
 


### PR DESCRIPTION
Notification alerts were updated in iOS 8.2 to include a Title Property, added support for this.  