### PR TITLE
Added ability to create an Apple Push Notification "WithJson()"

### DIFF
--- a/PushSharp.Apple/AppleFluentNotification.cs
+++ b/PushSharp.Apple/AppleFluentNotification.cs
@@ -9,6 +9,19 @@ namespace PushSharp
 {
 	public static class FluentNotification
 	{
+        public static AppleNotification WithJson(this AppleNotification n, string json)
+        {
+            try { Newtonsoft.Json.Linq.JObject.Parse(json); }
+            catch { throw new InvalidCastException("Invalid JSON detected!"); }
+
+            if (n.Payload == null)
+                n.Payload = new AppleNotificationPayload();
+
+            n.Payload.JsonData = json ;
+
+            return n;
+        }
+
 		public static AppleNotification ForDeviceToken(this AppleNotification n, string deviceToken)
 		{
 			n.DeviceToken = deviceToken;

--- a/PushSharp.Apple/AppleNotificationPayload.cs
+++ b/PushSharp.Apple/AppleNotificationPayload.cs
@@ -11,6 +11,11 @@ namespace PushSharp.Apple
 {
 	public class AppleNotificationPayload
 	{
+        /// <summary>
+        /// JSON Payload to be sent in the message. When this is set, only the payload in this JSON is sent.
+        /// </summary>
+        public string JsonData { get; set; }
+
 		public AppleNotificationAlert Alert { get; set; }
 
 		public int? ContentAvailable { get; set; }
@@ -74,51 +79,56 @@ namespace PushSharp.Apple
 
 		public string ToJson()
 		{
-			JObject json = new JObject();
+			if (!string.IsNullOrEmpty(this.JsonData))
+            {
+                return this.JsonData;
+            }
+            
+            JObject json = new JObject();
 
-			JObject aps = new JObject();
+            JObject aps = new JObject();
 
-			if (!this.Alert.IsEmpty)
-			{
+            if (!this.Alert.IsEmpty)
+            {
                 if (!string.IsNullOrEmpty(this.Alert.Body)
-					&& string.IsNullOrEmpty(this.Alert.LocalizedKey)
-					&& string.IsNullOrEmpty(this.Alert.ActionLocalizedKey)
-					&& (this.Alert.LocalizedArgs == null || this.Alert.LocalizedArgs.Count <= 0)
-					&& string.IsNullOrEmpty(this.Alert.LaunchImage)
+                    && string.IsNullOrEmpty(this.Alert.LocalizedKey)
+                    && string.IsNullOrEmpty(this.Alert.ActionLocalizedKey)
+                    && (this.Alert.LocalizedArgs == null || this.Alert.LocalizedArgs.Count <= 0)
+                    && string.IsNullOrEmpty(this.Alert.LaunchImage)
                     && !this.HideActionButton)
-				{
-					aps["alert"] = new JValue(this.Alert.Body);
-				}
-				else
-				{
-					JObject jsonAlert = new JObject();
+                {
+                    aps["alert"] = new JValue(this.Alert.Body);
+                }
+                else
+                {
+                    JObject jsonAlert = new JObject();
 
-					if (!string.IsNullOrEmpty(this.Alert.LocalizedKey))
-						jsonAlert["loc-key"] = new JValue(this.Alert.LocalizedKey);
+                    if (!string.IsNullOrEmpty(this.Alert.LocalizedKey))
+                        jsonAlert["loc-key"] = new JValue(this.Alert.LocalizedKey);
 
-					if (this.Alert.LocalizedArgs != null && this.Alert.LocalizedArgs.Count > 0)
-						jsonAlert["loc-args"] = new JArray(this.Alert.LocalizedArgs.ToArray());
+                    if (this.Alert.LocalizedArgs != null && this.Alert.LocalizedArgs.Count > 0)
+                        jsonAlert["loc-args"] = new JArray(this.Alert.LocalizedArgs.ToArray());
 
-					if (!string.IsNullOrEmpty(this.Alert.Body))
-						jsonAlert["body"] = new JValue(this.Alert.Body);
+                    if (!string.IsNullOrEmpty(this.Alert.Body))
+                        jsonAlert["body"] = new JValue(this.Alert.Body);
 
-					if (this.HideActionButton)
-						jsonAlert["action-loc-key"] = new JValue((string)null);
-					else if (!string.IsNullOrEmpty(this.Alert.ActionLocalizedKey))
-						jsonAlert["action-loc-key"] = new JValue(this.Alert.ActionLocalizedKey);
+                    if (this.HideActionButton)
+                        jsonAlert["action-loc-key"] = new JValue((string)null);
+                    else if (!string.IsNullOrEmpty(this.Alert.ActionLocalizedKey))
+                        jsonAlert["action-loc-key"] = new JValue(this.Alert.ActionLocalizedKey);
 
                     if (!string.IsNullOrEmpty(this.Alert.LaunchImage))
                         jsonAlert["launch-image"] = new JValue(this.Alert.LaunchImage);
 
-					aps["alert"] = jsonAlert;
-				}
-			}
+                    aps["alert"] = jsonAlert;
+                }
+            }
 
-			if (this.Badge.HasValue)
-				aps["badge"] = new JValue(this.Badge.Value);
+            if (this.Badge.HasValue)
+                aps["badge"] = new JValue(this.Badge.Value);
 
-			if (!string.IsNullOrEmpty(this.Sound))
-				aps["sound"] = new JValue(this.Sound);
+            if (!string.IsNullOrEmpty(this.Sound))
+                aps["sound"] = new JValue(this.Sound);
 
             if (this.ContentAvailable.HasValue)
             {
@@ -130,37 +140,37 @@ namespace PushSharp.Apple
                 }
             }
 
-			if (!string.IsNullOrEmpty(this.Category))
-			{
-				// iOS8 Interactive Notifications
-				aps["category"] = new JValue(this.Category);
-			}
+            if (!string.IsNullOrEmpty(this.Category))
+            {
+                // iOS8 Interactive Notifications
+                aps["category"] = new JValue(this.Category);
+            }
 
-		    if (aps.Count > 0)
-				json["aps"] = aps;
+            if (aps.Count > 0)
+                json["aps"] = aps;
 
-			foreach (string key in this.CustomItems.Keys)
-			{
-				if (this.CustomItems[key].Length == 1)
-				{
-					object custom = this.CustomItems[key][0];
-					json[key] = custom is JToken ? (JToken) custom : new JValue(custom);
-				}
-				else if (this.CustomItems[key].Length > 1)
-					json[key] = new JArray(this.CustomItems[key]);
-			}
+            foreach (string key in this.CustomItems.Keys)
+            {
+                if (this.CustomItems[key].Length == 1)
+                {
+                    object custom = this.CustomItems[key][0];
+                    json[key] = custom is JToken ? (JToken)custom : new JValue(custom);
+                }
+                else if (this.CustomItems[key].Length > 1)
+                    json[key] = new JArray(this.CustomItems[key]);
+            }
 
-			string rawString = json.ToString(Newtonsoft.Json.Formatting.None, null);
+            string rawString = json.ToString(Newtonsoft.Json.Formatting.None, null);
 
-			StringBuilder encodedString = new StringBuilder();
-			foreach (char c in rawString)
-			{
-				if ((int)c < 32 || (int)c > 127)
-					encodedString.Append("\\u" + String.Format("{0:x4}", Convert.ToUInt32(c)));
-				else
-					encodedString.Append(c);
-			}
-			return rawString;// encodedString.ToString();
+            StringBuilder encodedString = new StringBuilder();
+            foreach (char c in rawString)
+            {
+                if ((int)c < 32 || (int)c > 127)
+                    encodedString.Append("\\u" + String.Format("{0:x4}", Convert.ToUInt32(c)));
+                else
+                    encodedString.Append(c);
+            }
+            return rawString;// encodedString.ToString();
 		}
 
 		//public string ToJson()


### PR DESCRIPTION
This is simplest implementation necessary for Safari Push notifications.  The Json required for those push notifications is a little different that those for native apps (https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html#//apple_ref/doc/uid/TP40013225-CH3-SW12).  

I tried to make sure the code changes were made using the same patterns as other areas of the PushSharp library. (GcmNotification and GcmFluentNotification)