### PR TITLE
Fix bug GCM Authorization Failed #574

### DIFF
--- a/PushSharp.Google/GcmServiceConnection.cs
+++ b/PushSharp.Google/GcmServiceConnection.cs
@@ -38,27 +38,23 @@ namespace PushSharp.Google
         public GcmServiceConnection (GcmConfiguration configuration)
         {
             Configuration = configuration;
+            http = new HttpClient ();
+
+            http.DefaultRequestHeaders.UserAgent.Clear ();
+            http.DefaultRequestHeaders.UserAgent.Add (new ProductInfoHeaderValue ("PushSharp", "3.0"));
+            http.DefaultRequestHeaders.TryAddWithoutValidation ("Authorization", "key=" + Configuration.SenderAuthToken);
         }
 
         public GcmConfiguration Configuration { get; private set; }
 
-        readonly HttpClient http = new HttpClient ();
+        readonly HttpClient http;
 
         public async Task Send (GcmNotification notification)
         {
             var json = notification.GetJson ();
 
             var content = new StringContent (json, System.Text.Encoding.UTF8, "application/json");
-            http.DefaultRequestHeaders.UserAgent.Clear ();
-            http.DefaultRequestHeaders.UserAgent.Add (new ProductInfoHeaderValue ("PushSharp", "3.0"));
-            //http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue ("Authorization:", "key=" + Configuration.SenderAuthToken);
-            http.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "key=" + Configuration.SenderAuthToken);
 
-//            var req = new HttpRequestMessage (HttpMethod.Post, Configuration.GcmUrl);
-//            req.Headers.try.Add ("Authorization", "key=" + Configuration.SenderAuthToken);
-//            req.Content = content;
-
-            //var response = await http.SendAsync (req);
             var response = await http.PostAsync (Configuration.GcmUrl, content);
 
             if (response.IsSuccessStatusCode) {


### PR DESCRIPTION
'Authorization' Header was being appended to for each notification in
the service queue. This caused multiple notifications to fail as the
header got appended for each call. New code is simpler and should be
better performing. The auth headers are set only once at the creation of
the service connection