### PR TITLE
Reconnect to Apns in case of network failure

### DIFF
--- a/PushSharp.Apple/ApnsConfiguration.cs
+++ b/PushSharp.Apple/ApnsConfiguration.cs
@@ -92,6 +92,8 @@ namespace PushSharp.Apple
 
             InternalBatchSize = 1000;
             InternalBatchingWaitPeriod = TimeSpan.FromMilliseconds (750);
+
+            InternalBatchFailureRetryCount = 1;
         }
 
         public bool DetectProduction (X509Certificate2 certificate)
@@ -199,6 +201,12 @@ namespace PushSharp.Apple
         /// </summary>
         /// <value>The internal batching wait period.</value>
         public TimeSpan InternalBatchingWaitPeriod { get; set; }
+
+        /// <summary>
+        /// How many times the internal batch will retry to send in case of network failure. The default value is 1.
+        /// </summary>
+        /// <value>The internal batch failure retry count.</value>
+        public int InternalBatchFailureRetryCount { get; set; }
 
         /// <summary>
         /// Gets or sets the keep alive period to set on the APNS socket

--- a/PushSharp.Apple/ApnsConnection.cs
+++ b/PushSharp.Apple/ApnsConnection.cs
@@ -292,6 +292,12 @@ namespace PushSharp.Apple
             if (client == null)
                 return false;
 
+            if (networkStream == null || !networkStream.CanWrite)
+                return false;
+
+            if (!client.Client.Connected)
+                return false;
+
             var p = client.Client.Poll (1000, SelectMode.SelectWrite); 
 
             Log.Info ("APNS-Client[{0}]: Can Write? {1}", id, p);

--- a/PushSharp.Apple/ApnsConnection.cs
+++ b/PushSharp.Apple/ApnsConnection.cs
@@ -129,20 +129,30 @@ namespace PushSharp.Apple
 
             try {
 
-                await connectingSemaphore.WaitAsync ();
-
-                try {
-                    // See if we need to connect
-                    if (!socketCanWrite ())
-                        await connect ();
-                } finally {
-                    connectingSemaphore.Release ();
-                }
-                
                 var data = createBatch (toSend);
 
                 if (data != null && data.Length > 0) {
-                    await networkStream.WriteAsync (data, 0, data.Length).ConfigureAwait (false);
+
+                    for (var i = 0; i <= Configuration.InternalBatchFailureRetryCount; i++) {
+
+                        await connectingSemaphore.WaitAsync ();
+
+                        try {
+                            // See if we need to connect
+                            var retry = (i != 0 && i == Configuration.InternalBatchFailureRetryCount);
+                            if (!socketCanWrite () || retry)
+                                await connect ();
+                        } finally {
+                            connectingSemaphore.Release ();
+                        }
+                
+                        try {
+                            await networkStream.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+                            break;
+                        } catch (Exception ex) when (i != Configuration.InternalBatchFailureRetryCount) {
+                            Log.Info("APNS-CLIENT[{0}]: Retrying Batch: Batch ID={1}, Error={2}", id, batchId, ex);
+                        }
+                    }
 
                     foreach (var n in toSend)
                         sent.Add (new SentNotification (n));

--- a/PushSharp.Apple/ApnsConnection.cs
+++ b/PushSharp.Apple/ApnsConnection.cs
@@ -139,8 +139,7 @@ namespace PushSharp.Apple
 
                         try {
                             // See if we need to connect
-                            var retry = (i != 0 && i == Configuration.InternalBatchFailureRetryCount);
-                            if (!socketCanWrite () || retry)
+                            if (!socketCanWrite () || i > 0)
                                 await connect ();
                         } finally {
                             connectingSemaphore.Release ();

--- a/PushSharp.Apple/Exceptions.cs
+++ b/PushSharp.Apple/Exceptions.cs
@@ -19,19 +19,27 @@ namespace PushSharp.Apple
 
     public class ApnsNotificationException : Exception
     {
-        public ApnsNotificationException (byte errorStatusCode, ApnsNotification notification) : base ()
+        public ApnsNotificationException(byte errorStatusCode, ApnsNotification notification)
+            : this(ToErrorStatusCode(errorStatusCode), notification)
+        { }
+
+        public ApnsNotificationException (ApnsNotificationErrorStatusCode errorStatusCode, ApnsNotification notification)
+            : base ($"Apns notification error: '{errorStatusCode}'")
         {
             Notification = notification;
-
-            var s = ApnsNotificationErrorStatusCode.Unknown;
-            Enum.TryParse<ApnsNotificationErrorStatusCode> (errorStatusCode.ToString (), out s);
-            ErrorStatusCode = s;
-
+            ErrorStatusCode = errorStatusCode;
         }
 
         public ApnsNotification Notification { get; set; }
 
         public ApnsNotificationErrorStatusCode ErrorStatusCode { get; private set; }
+        
+        private static ApnsNotificationErrorStatusCode ToErrorStatusCode(byte errorStatusCode)
+        {
+            var s = ApnsNotificationErrorStatusCode.Unknown;
+            Enum.TryParse<ApnsNotificationErrorStatusCode>(errorStatusCode.ToString(), out s);
+            return s;
+        }
     }
 
     public class ApnsConnectionException : Exception


### PR DESCRIPTION
This PR addresses the Apns idle tcp connection problem mentioned by @khanhvu161188. 

I add more checks to `socketCanWrite` method so we knows better if the connection is good.

In case of failure writing to the network stream (due to idle or some other reasons), it will retry the batch for a specific times until success.

I also include the `ApnsNotificationErrorStatusCode` in the exception message of `ApnsNotificationException`, because I often see that exception in logs and want's to know what exactly is going wrong.
 