### PR TITLE
Fixed error when sending multiple windows push messages at once

### DIFF
--- a/PushSharp.Tests/WnsRealTests.cs
+++ b/PushSharp.Tests/WnsRealTests.cs
@@ -38,7 +38,7 @@ namespace PushSharp.Tests
                         <toast>
                             <visual>
                                 <binding template=""ToastText01"">
-                                    <text id=""1"">bodyText</text>
+                                    <text id=""1"">WNS_Send_Single</text>
                                 </binding>  
                             </visual>
                         </toast>
@@ -50,6 +50,56 @@ namespace PushSharp.Tests
 
             Assert.AreEqual (attempted, succeeded);
             Assert.AreEqual (0, failed);
+        }
+
+        [Test]
+        public void WNS_Send_Mutiple()
+        {
+            var succeeded = 0;
+            var failed = 0;
+            var attempted = 0;
+
+            var config = new WnsConfiguration(Settings.Instance.WnsPackageName,
+                             Settings.Instance.WnsPackageSid,
+                             Settings.Instance.WnsClientSecret);
+
+            var broker = new WnsServiceBroker(config);
+            broker.OnNotificationFailed += (notification, exception) =>
+            {
+                failed++;
+            };
+            broker.OnNotificationSucceeded += (notification) =>
+            {
+                succeeded++;
+            };
+
+            broker.Start();
+
+            foreach (var uri in Settings.Instance.WnsChannelUris)
+            {
+                for (var i = 1; i <= 3; i++)
+                {
+                    attempted++;
+                    broker.QueueNotification(new WnsToastNotification
+                    {
+                        ChannelUri = uri,
+                        Payload = XElement.Parse(@"
+                        <toast>
+                            <visual>
+                                <binding template=""ToastText01"">
+                                    <text id=""1"">WNS_Send_Multiple " + i.ToString() + @"</text>
+                                </binding>  
+                            </visual>
+                        </toast>
+                    ")
+                    });
+                }
+            }
+
+            broker.Stop();
+
+            Assert.AreEqual(attempted, succeeded);
+            Assert.AreEqual(0, failed);
         }
     }
 }

--- a/PushSharp.Windows/Exceptions.cs
+++ b/PushSharp.Windows/Exceptions.cs
@@ -12,6 +12,11 @@ namespace PushSharp.Windows
 
         public new WnsNotification Notification { get; set; }
         public WnsNotificationStatus Status { get; private set; }
+
+        public override string ToString()
+        {
+            return base.ToString() + " Status = " + Status.HttpStatus;
+        }
     }
 }
 


### PR DESCRIPTION
- Created a WnsAccessTokenManager to share the accesstoken between WnsConnections
- HttpUnauthorized invalidates the accesstoken
- Added extra info in the wnsexception about the httpstatus
- Added an unittest for sending multiple notifications at once.