### PR TITLE
Fixed tracked notifications negative. Problem instantiating channels (fixed number).

### DIFF
--- a/PushSharp.Core/PushServiceBase.cs
+++ b/PushSharp.Core/PushServiceBase.cs
@@ -116,9 +116,6 @@ namespace PushSharp.Core
 			if (this.ServiceSettings.MaxNotificationRequeues < 0 ||
 			    notification.QueuedCount <= this.ServiceSettings.MaxNotificationRequeues)
 			{ 
-                // Increment our counter
-                Interlocked.Increment(ref trackedNotificationCount);
-
                 //Reset Enqueued time in case this is a requeue
 				notification.EnqueuedTimestamp = DateTime.UtcNow;
 
@@ -291,7 +288,7 @@ namespace PushSharp.Core
 						}
                         while (ChannelCount < ServiceSettings.Channels && !this.cancelTokenSource.IsCancellationRequested
                             && (DateTime.UtcNow - lastNotificationQueueTime) <= ServiceSettings.IdleTimeout
-                            && Interlocked.Read(ref trackedNotificationCount) > 0)
+                            && QueueLength > 0)
 						{
 							Log.Info("{0} -> Creating Channel", this);
 							ScaleChannels(ChannelScaleAction.Create);
@@ -450,6 +447,11 @@ namespace PushSharp.Core
 					Thread.Sleep(100);
 					continue;
 				}
+                else
+                {
+                    // Increment our counter - messages being sent
+                    Interlocked.Increment(ref trackedNotificationCount);
+                }
 
                 ManualResetEvent waitForNotification = null;
 
@@ -478,8 +480,6 @@ namespace PushSharp.Core
 
 				channel.SendNotification(notification, (sender, result) =>
 					{
-						Interlocked.Decrement(ref trackedNotificationCount);
-                        
 						var sendTime = DateTime.UtcNow - sendStart;
 
                         lock (sendTimeMeasurementsLock)
@@ -547,8 +547,6 @@ namespace PushSharp.Core
 
                 if (waitForNotification != null && !waitForNotification.WaitOne(ServiceSettings.NotificationSendTimeout))
                 {
-					Interlocked.Decrement(ref trackedNotificationCount);
-
 					Log.Info("Notification send timeout");
 
 					var evt = this.OnNotificationFailed;
@@ -561,9 +559,12 @@ namespace PushSharp.Core
                     waitForNotification.Close();
                     waitForNotification = null;
                 }
-			}
 
-			channel.Dispose();
+                Interlocked.Decrement(ref trackedNotificationCount);
+
+            }
+
+            channel.Dispose();
 		}
 
 		internal class WaitTimeMeasurement

--- a/PushSharp.Core/PushServiceBase.cs
+++ b/PushSharp.Core/PushServiceBase.cs
@@ -288,7 +288,7 @@ namespace PushSharp.Core
 						}
                         while (ChannelCount < ServiceSettings.Channels && !this.cancelTokenSource.IsCancellationRequested
                             && (DateTime.UtcNow - lastNotificationQueueTime) <= ServiceSettings.IdleTimeout
-                            && QueueLength > 0)
+                            && (Interlocked.Read(ref trackedNotificationCount) > 0 || QueueLength > 0))
 						{
 							Log.Info("{0} -> Creating Channel", this);
 							ScaleChannels(ChannelScaleAction.Create);


### PR DESCRIPTION
I've experienced a problem in production with notifications being queued but not sent. This turned out to be a problem instantiating the Channels (non-AutoScale). It's because trackedNotificationCount, i.e. messages being sent, was negative because while there is a Decrement in the beginning of the SendNotification callback, there's another Decrement on NotificationSendTimeout (L548). I changed the condition to instantiate channels (non-AutoScale) to look at QueueLength before creating channels. Also changed location of trackedNotificationCount increment to fit the concept of "messages being sent - processing".