### PR TITLE
Fixed error when using To instead of RegistrationId - GCM

### DIFF
--- a/PushSharp.Google/GcmNotification.cs
+++ b/PushSharp.Google/GcmNotification.cs
@@ -14,7 +14,10 @@ namespace PushSharp.Google
             var result = new GcmNotification ();
             result.Tag = response.OriginalNotification.Tag;
             result.MessageId = response.OriginalNotification.MessageId;
-            result.RegistrationIds.Add (response.OriginalNotification.RegistrationIds [resultIndex]);
+
+            if (response.OriginalNotification.RegistrationIds != null && response.OriginalNotification.RegistrationIds.Count >= (resultIndex + 1))
+                result.RegistrationIds.Add (response.OriginalNotification.RegistrationIds [resultIndex]);
+
             result.CollapseKey = response.OriginalNotification.CollapseKey;
             result.Data = response.OriginalNotification.Data;
             result.DelayWhileIdle = response.OriginalNotification.DelayWhileIdle;

--- a/PushSharp.Google/GcmServiceConnection.cs
+++ b/PushSharp.Google/GcmServiceConnection.cs
@@ -119,7 +119,13 @@ namespace PushSharp.Google
                     var oldRegistrationId = string.Empty;
 
                     if (singleResultNotification.RegistrationIds != null && singleResultNotification.RegistrationIds.Count > 0)
-                        oldRegistrationId = singleResultNotification.RegistrationIds [0];
+                    {
+                        oldRegistrationId = singleResultNotification.RegistrationIds[0];
+                    }
+                    else if (!string.IsNullOrEmpty(singleResultNotification.To))
+                    {
+                        oldRegistrationId = singleResultNotification.To;
+                    }
 
                     multicastResult.Failed.Add (singleResultNotification, new DeviceSubscriptonExpiredException {
                         OldSubscriptionId = oldRegistrationId,
@@ -131,7 +137,13 @@ namespace PushSharp.Google
                     var oldRegistrationId = string.Empty;
 
                     if (singleResultNotification.RegistrationIds != null && singleResultNotification.RegistrationIds.Count > 0)
-                        oldRegistrationId = singleResultNotification.RegistrationIds [0];
+                    {
+                        oldRegistrationId = singleResultNotification.RegistrationIds[0];
+                    }
+                    else if (!string.IsNullOrEmpty(singleResultNotification.To))
+                    {
+                        oldRegistrationId = singleResultNotification.To;
+                    }   
 
                     multicastResult.Failed.Add (singleResultNotification, new DeviceSubscriptonExpiredException { OldSubscriptionId = oldRegistrationId });
                 } else {


### PR DESCRIPTION
Fix for NullReferenceException issue -
https://github.com/Redth/PushSharp/issues/629

Additional fix for retrieving oldRegistrationId from the 'To' field if
'RegistrationIds' is empty or null