### PR TITLE
prevent double Authorization header values in WNS connection

### DIFF
--- a/PushSharp.Windows/WnsConnection.cs
+++ b/PushSharp.Windows/WnsConnection.cs
@@ -63,7 +63,8 @@ namespace PushSharp.Windows
             var http = new HttpClient ();
 
             http.DefaultRequestHeaders.TryAddWithoutValidation ("X-WNS-Type", string.Format ("wns/{0}", notification.Type.ToString ().ToLower ()));
-            http.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "Bearer " + accessToken);
+            if(!http.DefaultRequestHeaders.Contains("Authorization")) //prevent double values
+                http.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "Bearer " + accessToken);
 
             if (notification.RequestForStatus.HasValue)
                 http.DefaultRequestHeaders.TryAddWithoutValidation ("X-WNS-RequestForStatus", notification.RequestForStatus.Value.ToString().ToLower());


### PR DESCRIPTION
### What version of PushSharp are you using?
3.0.1

### Describe your issue:
After one notification on the WNS connection the Authorization header gets wrong. Seems that 
```csharp
http.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "encrypted token")"
```
produce double values in case header contains already Authorization part.

### What are the steps required to reproduce this issue?
Setup a sendout for any enabled WNS app and send 2 messages to one device, first message arrive, second message is blocked by WNS.

### Please provide any Exception Stack Traces
n/a

### Headers
- first message
```
POST https://db5.notify.windows.com/?token=xxxxxxxx HTTP/1.1
X-WNS-Type: wns/toast
Authorization: Bearer EgAdAQMAAAAEgAAAC4AAajnqa71rFQ2iVBQvhZGGsQem3vv8LBvEeFaJeU9uCJRmmSGomjENWvAJRlT0tlfKutJ5Qc4cvJXMTJmi7NGnkuB6LIhMnnDGjtjlIPclhaBpt7thQ4tqHMkdCHZ3uV5/bCqM8cOqcus0toqtW2urQFF8bDrK89sX8RSnYuYQBXCMAFoAjAAAAAAAD3IWRHX331Z1999W60gEAA4AODAuMTQ2LjI0NS45OQAAAAAAXgBtcy1hcHA6Ly9zLTEtMTUtMi00NTUzMjcyMDgtMTk0MjU4MTEwOC0yMjc4MTIwMTEwLTE1Nzg0MjU4MzQtMjQyMjEzNDk0NS0yOTM0NjkyOTk1LTE0MDU2NTMwMTAA
Content-Type: text/xml; charset=utf-8
Host: db5.notify.windows.com
Content-Length: 164
```

- second message
```
POST https://db5.notify.windows.com/?token=xxxxxxxx HTTP/1.1
X-WNS-Type: wns/toast
Authorization: Bearer EgAdAQMAAAAEgAAAC4AAajnqa71rFQ2iVBQvhZGGsQem3vv8LBvEeFaJeU9uCJRmmSGomjENWvAJRlT0tlfKutJ5Qc4cvJXMTJmi7NGnkuB6LIhMnnDGjtjlIPclhaBpt7thQ4tqHMkdCHZ3uV5/bCqM8cOqcus0toqtW2urQFF8bDrK89sX8RSnYuYQBXCMAFoAjAAAAAAAD3IWRHX331Z1999W60gEAA4AODAuMTQ2LjI0NS45OQAAAAAAXgBtcy1hcHA6Ly9zLTEtMTUtMi00NTUzMjcyMDgtMTk0MjU4MTEwOC0yMjc4MTIwMTEwLTE1Nzg0MjU4MzQtMjQyMjEzNDk0NS0yOTM0NjkyOTk1LTE0MDU2NTMwMTAA, Bearer EgAdAQMAAAAEgAAAC4AAajnqa71rFQ2iVBQvhZGGsQem3vv8LBvEeFaJeU9uCJRmmSGomjENWvAJRlT0tlfKutJ5Qc4cvJXMTJmi7NGnkuB6LIhMnnDGjtjlIPclhaBpt7thQ4tqHMkdCHZ3uV5/bCqM8cOqcus0toqtW2urQFF8bDrK89sX8RSnYuYQBXCMAFoAjAAAAAAAD3IWRHX331Z1999W60gEAA4AODAuMTQ2LjI0NS45OQAAAAAAXgBtcy1hcHA6Ly9zLTEtMTUtMi00NTUzMjcyMDgtMTk0MjU4MTEwOC0yMjc4MTIwMTEwLTE1Nzg0MjU4MzQtMjQyMjEzNDk0NS0yOTM0NjkyOTk1LTE0MDU2NTMwMTAA
Content-Type: text/xml; charset=utf-8
Host: db5.notify.windows.com
Content-Length: 164
```
