### PR TITLE
Option to use a Proxy when connecting to APNS

### DIFF
--- a/PushSharp.Apple/ApnsConfiguration.cs
+++ b/PushSharp.Apple/ApnsConfiguration.cs
@@ -109,19 +109,19 @@ namespace PushSharp.Apple
                 var commonName = Certificate.SubjectName.Name;
 
                 if (!issuerName.Contains ("Apple"))
-                    throw new ApnsConnectionException ("Your Certificate does not appear to be issued by Apple!  Please check to ensure you have the correct certificate!");
+                    throw new ArgumentOutOfRangeException ("Your Certificate does not appear to be issued by Apple!  Please check to ensure you have the correct certificate!");
 
                 if (!Regex.IsMatch (commonName, "Apple.*?Push Services")
                     && !commonName.Contains ("Website Push ID:"))
-                    throw new ApnsConnectionException ("Your Certificate is not a valid certificate for connecting to Apple's APNS servers");
+                    throw new ArgumentOutOfRangeException ("Your Certificate is not a valid certificate for connecting to Apple's APNS servers");
 
                 if (commonName.Contains ("Development") && ServerEnvironment != ApnsServerEnvironment.Sandbox)
-                    throw new ApnsConnectionException ("You are using a certificate created for connecting only to the Sandbox APNS server but have selected a different server environment to connect to.");
+                    throw new ArgumentOutOfRangeException ("You are using a certificate created for connecting only to the Sandbox APNS server but have selected a different server environment to connect to.");
 
                 if (commonName.Contains ("Production") && ServerEnvironment != ApnsServerEnvironment.Production)
-                    throw new ApnsConnectionException ("You are using a certificate created for connecting only to the Production APNS server but have selected a different server environment to connect to.");
+                    throw new ArgumentOutOfRangeException ("You are using a certificate created for connecting only to the Production APNS server but have selected a different server environment to connect to.");
             } else {
-                throw new ApnsConnectionException ("You must provide a Certificate to connect to APNS with!");
+                throw new ArgumentOutOfRangeException ("You must provide a Certificate to connect to APNS with!");
             }
         }
 

--- a/PushSharp.Apple/ApnsConfiguration.cs
+++ b/PushSharp.Apple/ApnsConfiguration.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 
@@ -108,19 +109,19 @@ namespace PushSharp.Apple
                 var commonName = Certificate.SubjectName.Name;
 
                 if (!issuerName.Contains ("Apple"))
-                    throw new ArgumentOutOfRangeException ("Your Certificate does not appear to be issued by Apple!  Please check to ensure you have the correct certificate!");
+                    throw new ApnsConnectionException ("Your Certificate does not appear to be issued by Apple!  Please check to ensure you have the correct certificate!");
 
                 if (!Regex.IsMatch (commonName, "Apple.*?Push Services")
                     && !commonName.Contains ("Website Push ID:"))
-                    throw new ArgumentOutOfRangeException ("Your Certificate is not a valid certificate for connecting to Apple's APNS servers");
+                    throw new ApnsConnectionException ("Your Certificate is not a valid certificate for connecting to Apple's APNS servers");
 
                 if (commonName.Contains ("Development") && ServerEnvironment != ApnsServerEnvironment.Sandbox)
-                    throw new ArgumentOutOfRangeException ("You are using a certificate created for connecting only to the Sandbox APNS server but have selected a different server environment to connect to.");
+                    throw new ApnsConnectionException ("You are using a certificate created for connecting only to the Sandbox APNS server but have selected a different server environment to connect to.");
 
                 if (commonName.Contains ("Production") && ServerEnvironment != ApnsServerEnvironment.Production)
-                    throw new ArgumentOutOfRangeException ("You are using a certificate created for connecting only to the Production APNS server but have selected a different server environment to connect to.");
+                    throw new ApnsConnectionException ("You are using a certificate created for connecting only to the Production APNS server but have selected a different server environment to connect to.");
             } else {
-                throw new ArgumentOutOfRangeException ("You must provide a Certificate to connect to APNS with!");
+                throw new ApnsConnectionException ("You must provide a Certificate to connect to APNS with!");
             }
         }
 
@@ -136,6 +137,22 @@ namespace PushSharp.Apple
             FeedbackPort = port;
         }
 
+        public void SetProxy(string proxyHost, int proxyPort)
+        {
+            UseProxy = true;
+            ProxyHost = proxyHost;
+            ProxyPort = proxyPort;
+            ProxyCredentials = CredentialCache.DefaultNetworkCredentials;
+        }
+
+        public void SetProxy(string proxyHost, int proxyPort, string userName, string password, string domain)
+        {
+            UseProxy = true;
+            ProxyHost = proxyHost;
+            ProxyPort = proxyPort;
+            ProxyCredentials = new NetworkCredential(userName, password, domain);
+        }
+
         public string Host { get; private set; }
 
         public int Port { get; private set; }
@@ -144,6 +161,14 @@ namespace PushSharp.Apple
 
         public int FeedbackPort { get; private set; }
 
+        public bool UseProxy { get; private set; }
+
+        public string ProxyHost { get; private set; }
+
+        public int ProxyPort { get; private set; }
+
+        public NetworkCredential ProxyCredentials { get; private set; }
+        
         public X509Certificate2 Certificate { get; private set; }
 
         public List<X509Certificate2> AdditionalCertificates { get; private set; }

--- a/PushSharp.Apple/ApnsConnection.cs
+++ b/PushSharp.Apple/ApnsConnection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net.Sockets;
 using System.Net.Security;
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Net;
 using PushSharp.Core;
+using System.Diagnostics;
 
 namespace PushSharp.Apple
 {
@@ -160,7 +161,7 @@ namespace PushSharp.Apple
             } catch (Exception ex) {
                 Log.Error ("APNS-CLIENT[{0}]: Send Batch Error: Batch ID={1}, Error={2}", id, batchId, ex);
                 foreach (var n in toSend)
-                    n.CompleteFailed (new ApnsNotificationException (ApnsNotificationErrorStatusCode.ConnectionError, n.Notification, ex));
+                    n.CompleteFailed (ex);
             }
 
             Log.Info ("APNS-Client[{0}]: Sent Batch, waiting for possible response...", id);
@@ -239,7 +240,7 @@ namespace PushSharp.Apple
                 sent.Clear ();
                 return;
             }
-
+            
             // If we make it here, we did get data back, so we have errors
 
             Log.Info ("APNS-Client[{0}]: Batch (ID={1}) completed with error response...", id, batchId);
@@ -314,6 +315,55 @@ namespace PushSharp.Apple
             return p;
         }
 
+
+        /// <summary>
+        /// Source:
+        /// https://web.archive.org/web/20160317134733/https://nitormobiledevelopment.wordpress.com/2013/08/13/push-sharp-using-proxy/
+        /// </summary>
+        /// <param name="targetHost"></param>
+        /// <param name="targetPort"></param>
+        /// <param name="httpProxyHost"></param>
+        /// <param name="httpProxyPort"></param>
+        /// <returns></returns>
+        private TcpClient getClientViaHTTPProxy(string targetHost, int targetPort, string httpProxyHost, int httpProxyPort)
+        {
+            try
+            {
+                var uriBuilder = new UriBuilder
+                {
+                    Scheme = Uri.UriSchemeHttp,
+                    Host = httpProxyHost,
+                    Port = httpProxyPort
+                };
+                var proxyUri = uriBuilder.Uri;
+                var request = WebRequest.Create("http://" + targetHost + ":" + targetPort);
+                var webProxy = new WebProxy(proxyUri);
+                request.Proxy = webProxy;
+                request.Method = "CONNECT";
+                webProxy.Credentials = Configuration.ProxyCredentials;
+                var response = request.GetResponse();
+                var responseStream = response.GetResponseStream();
+                Debug.Assert(responseStream != null);
+                const System.Reflection.BindingFlags Flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+                var rsType = responseStream.GetType();
+                var connectionProperty = rsType.GetProperty("Connection", Flags);
+                var connection = connectionProperty.GetValue(responseStream, null);
+                var connectionType = connection.GetType();
+                var networkStreamProperty = connectionType.GetProperty("NetworkStream", Flags);
+                Stream networkStream1 = (Stream)networkStreamProperty.GetValue(connection, null);
+                var nsType = networkStream1.GetType();
+                var socketProperty = nsType.GetProperty("Socket", Flags);
+                var socket = (Socket)socketProperty.GetValue(networkStream1, null);
+                return new TcpClient { Client = socket };
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message);
+                throw;
+            }
+        }
+
+
         async Task connect ()
         {            
             if (client != null)
@@ -321,10 +371,21 @@ namespace PushSharp.Apple
             
             Log.Info ("APNS-Client[{0}]: Connecting (Batch ID={1})", id, batchId);
 
-            client = new TcpClient ();
+            if (Configuration.UseProxy)
+            {
+                client = getClientViaHTTPProxy(Configuration.Host, Configuration.Port, Configuration.ProxyHost, Configuration.ProxyPort);
+            }
+            else
+            {
+                client = new TcpClient();
+            }
 
-            try {
-                await client.ConnectAsync (Configuration.Host, Configuration.Port).ConfigureAwait (false);
+            try
+            {
+                if (!Configuration.UseProxy)
+                {
+                    await client.ConnectAsync (Configuration.Host, Configuration.Port).ConfigureAwait (false);
+                }
 
                 //Set keep alive on the socket may help maintain our APNS connection
                 try {
@@ -349,7 +410,7 @@ namespace PushSharp.Apple
 
                 // Create our ssl stream
                 stream = new SslStream (client.GetStream (), 
-                    false,
+                    true,
                     ValidateRemoteCertificate,
                     (sender, targetHost, localCerts, remoteCert, acceptableIssuers) => certificate);
 

--- a/PushSharp.Apple/ApnsConnection.cs
+++ b/PushSharp.Apple/ApnsConnection.cs
@@ -161,7 +161,7 @@ namespace PushSharp.Apple
             } catch (Exception ex) {
                 Log.Error ("APNS-CLIENT[{0}]: Send Batch Error: Batch ID={1}, Error={2}", id, batchId, ex);
                 foreach (var n in toSend)
-                    n.CompleteFailed (ex);
+                    n.CompleteFailed (new ApnsNotificationException (ApnsNotificationErrorStatusCode.ConnectionError, n.Notification, ex));
             }
 
             Log.Info ("APNS-Client[{0}]: Sent Batch, waiting for possible response...", id);

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You may also specify a username, password and domain to authenticate against the
 
 A method to tunnel the TCP-connection via a pre-configured HTTP-Proxy has been added. If Configuration.SetProxy has been called, a CONNECT-request is sent using the proxy adress specified. The socket is then extracted from the stream of this request's response (using the System.Reflection-Library) and used to create a TcpClient-object. All traffic sent through this TcpClient-object will pass through the proxy used to send the initial CONNECT-Request.
 
-###Important notice###
+### Important notice
 The APNS Binary API has been declared obsolete and is being discontinued by apple in Favor of the HTTP/2 REST-API. Binary API will not be supported after March 31st 2021!
 More info: https://developer.apple.com/news/?id=c88acm2b
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+
+This Fork
+=========
+This fork adds HTTP-proxy support for APNS binary API.
+
+A user of the library can specify an HTTP-Proxy to tunnel all requests to and responses from APNS by calling SetProxy on ApnsConfiguration before creating the PushBroker
+
+```
+ApnsConfiguration configuration = new ApnsConfiguration(ApnsConfiguration.ApnsServerEnvironment.Production, certificatePath, certPwd, false);
+configuration.SetProxy("yourProxyIP", 3128);
+pushBroker = new ApnsServiceBroker(configuration);
+```
+
+You may also specify a username, password and domain to authenticate against the Proxy. If nothing is specified, the Default Network Credentials will be used:
+
+`configuration.SetProxy("yourProxyIP", 3128, "proxyUser", "proxyPassword", "MY_DOMAIN");`
+
+A method to tunnel the TCP-connection via a pre-configured HTTP-Proxy has been added. If Configuration.SetProxy has been called, a CONNECT-request is sent using the proxy adress specified. The socket is then extracted from the stream of this request's response (using the System.Reflection-Library) and used to create a TcpClient-object. All traffic sent through this TcpClient-object will pass through the proxy used to send the initial CONNECT-Request.
+
+###Important notice###
+The APNS Binary API has been declared obsolete and is being discontinued by apple in Favor of the HTTP/2 REST-API. Binary API will not be supported after March 31st 2021!
+More info: https://developer.apple.com/news/?id=c88acm2b
+
+
 PushSharp v3.0
 ==============
 


### PR DESCRIPTION
A user of the library can specify an HTTP-Proxy to tunnel all requests to and responses from APNS by calling SetProxy on ApnsConfiguration before creating the PushBroker

`ApnsConfiguration configuration = new ApnsConfiguration(ApnsConfiguration.ApnsServerEnvironment.Production, certificatePath, certPwd, false);`
`configuration.SetProxy("yourProxyIP", 3128);`
`pushBroker = new ApnsServiceBroker(configuration);`

You may also specify a username, password and domain to authenticate against the Proxy. If nothing is specified, the Default Network Credentials will be used:

`configuration.SetProxy("yourProxyIP", 3128, "proxyUser", "proxyPassword", "MY_DOMAIN");`

A method to tunnel the TCP-connection via a pre-configured HTTP-Proxy has been added. If Configuration.SetProxy has been called, a CONNECT-request is sent using the proxy adress specified. The socket is then extracted from the stream of this request's response (using the System.Reflection-Library) and used to create a TcpClient-object. All traffic sent through this TcpClient-object will pass through the proxy used to send the initial CONNECT-Request.

NOTE:
The method 'getClientViaHTTPProxy' in  the class 'APNSConnection' uses code that was not written by the author of this pull request. The original code can be found here:
https://web.archive.org/web/20160317134733/https://nitormobiledevelopment.wordpress.com/2013/08/13/push-sharp-using-proxy/
