### PR TITLE
Add support for Toast notifications

### DIFF
--- a/PushSharp.Windows/WnsConnection.cs
+++ b/PushSharp.Windows/WnsConnection.cs
@@ -89,6 +89,10 @@ namespace PushSharp.Windows
                 if (winTileBadge != null && winTileBadge.CachePolicy.HasValue)
                     http.DefaultRequestHeaders.Add("X-WNS-Cache-Policy", winTileBadge.CachePolicy == WnsNotificationCachePolicyType.Cache ? "cache" : "no-cache");
             }
+            else if(notification.Type == WnsNotificationType.Toast)
+            {
+                http.DefaultRequestHeaders.TryAddWithoutValidation("X-WindowsPhone-Target", notification.Type.ToString().ToLower());
+            }
 
             HttpContent content = null;
 
@@ -161,7 +165,7 @@ namespace PushSharp.Windows
             var wnsDeviceConnectionStatus = TryGetHeaderValue (resp.Headers, "X-WNS-DEVICECONNECTIONSTATUS") ?? "connected";
             var wnsErrorDescription = TryGetHeaderValue (resp.Headers, "X-WNS-ERROR-DESCRIPTION") ?? "";
             var wnsMsgId = TryGetHeaderValue (resp.Headers, "X-WNS-MSG-ID");
-            var wnsNotificationStatus = TryGetHeaderValue (resp.Headers, "X-WNS-NOTIFICATIONSTATUS") ?? "";
+            var wnsNotificationStatus = TryGetHeaderValue (resp.Headers, "X-WNS-NOTIFICATIONSTATUS") ?? TryGetHeaderValue(resp.Headers, "X-NOTIFICATIONSTATUS") ?? "" ;
 
             result.DebugTrace = wnsDebugTrace;
             result.ErrorDescription = wnsErrorDescription;


### PR DESCRIPTION
You need to send header X-WindowsPhone-Target for WP 7.1

xml for toast should look like:

<?xml version="1.0" encoding="UTF-8"?>
<wp:Notification xmlns:wp="WPNotification">
   wp:Toast
      wp:Text1Title/wp:Text1
      wp:Text2Message/wp:Text2
      wp:Param/MainPage/MainPage.xaml/wp:Param
   /wp:Toast
/wp:Notification

in your example is a mistake. I think You should to improve this.

In recieve headers You need to read X-NOTIFICATIONSTATUS to set wnsNotificationStatus as recieved

best regards
Mariusz
