### PR TITLE
Readme: Failed → Succeeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ gcmBroker.OnNotificationFailed += (notification, aggregateEx) => {
 			var multicastException = (GcmMulticastResultException)ex;
 
 			foreach (var succeededNotification in multicastException.Succeeded) {
-				Console.WriteLine ($"GCM Notification Failed: ID={succeededNotification.MessageId}");
+				Console.WriteLine ($"GCM Notification Succeeded: ID={succeededNotification.MessageId}");
 			}
 
 			foreach (var failedKvp in multicastException.Failed) {


### PR DESCRIPTION
I believe there's an error in the classification. The multicast exception divides all the messages into two groups: succeeded and failed. The current sample will print them all as failed.