### PR TITLE
apns - handling error from previous batch

### DIFF
--- a/PushSharp.Apple/ApnsConfiguration.cs
+++ b/PushSharp.Apple/ApnsConfiguration.cs
@@ -79,6 +79,7 @@ namespace PushSharp.Apple
             MillisecondsToWaitBeforeMessageDeclaredSuccess = 3000;
             ConnectionTimeout = 10000;
             MaxConnectionAttempts = 3;
+            ResponseWaitTimeout = 750;
 
             FeedbackIntervalMinutes = 10;
             FeedbackTimeIsUTC = false;
@@ -161,6 +162,8 @@ namespace PushSharp.Apple
         public bool ValidateServerCertificate { get; set; }
 
         public int ConnectionTimeout { get; set; }
+
+        public int ResponseWaitTimeout { get; set; }
 
         public int MaxConnectionAttempts { get; set; }
 

--- a/PushSharp.Apple/ApnsConnection.cs
+++ b/PushSharp.Apple/ApnsConnection.cs
@@ -199,7 +199,7 @@ namespace PushSharp.Apple
             // read (in the case that all the messages sent successfully, apple will send us nothing
             // So, let's make our read timeout after a reasonable amount of time to wait for apple to tell
             // us of any errors that happened.
-            readCancelToken.CancelAfter (750);
+            readCancelToken.CancelAfter (Configuration.ResponseWaitTimeout);
 
             int len = -1;
 
@@ -252,10 +252,17 @@ namespace PushSharp.Apple
             //Get the index of our failed notification (by identifier)
             var failedIndex = sent.FindIndex (n => n.Identifier == identifier);
 
-            // If we didn't find an index for the failed notification, something is wrong
-            // Let's just return
+            // Looks like failed index was from previous batch. The reason is that readCancelToken timeout wasn't enought
+            // to get response from apns. 
+            // So put notifications from current batch again to queue and use new socket for next batches
+            // TODO: check that notifications from current batch weren't sent
             if (failedIndex < 0)
+            {
+                Log.Info("APNS-Client[{0}]: Cant find failing notification {1} in current batch", id, identifier);
+
+                EnqueRemainingBatchItems();
                 return;
+            }
 
             // Get all the notifications before the failed one and mark them as sent!
             if (failedIndex > 0) {
@@ -286,14 +293,19 @@ namespace PushSharp.Apple
             // The remaining items in the list were sent after the failed notification
             // we can assume these were ignored by apple so we need to send them again
             // Requeue the remaining notifications
+            EnqueRemainingBatchItems();
+        }
+
+        private void EnqueRemainingBatchItems()
+        {
             foreach (var s in sent)
-                notifications.Enqueue (s.Notification);
+                notifications.Enqueue(s.Notification);
 
             // Clear our sent list
-            sent.Clear ();
+            sent.Clear();
 
             // Apple will close our connection after this anyway
-            disconnect ();
+            disconnect();
         }
 
         bool socketCanWrite ()
@@ -306,6 +318,15 @@ namespace PushSharp.Apple
 
             if (!client.Client.Connected)
                 return false;
+
+            // looks like response for previous batch wasn't read (and some errors were in previous batch)
+            // Unfortunatelly we already notified client that notifications were sent. 
+            // But at least we won't use this socket for new batch...
+            if (client.Available > 0)
+            {
+                Log.Info("APNS-Client[{0}]: Previous batch wasn't processed correctly. Try to increase ResponseWaitTimeout");
+                return false;
+            }
 
             var p = client.Client.Poll (1000, SelectMode.SelectWrite); 
 

--- a/PushSharp.Apple/ApnsConnection.cs
+++ b/PushSharp.Apple/ApnsConnection.cs
@@ -255,12 +255,10 @@ namespace PushSharp.Apple
             // Looks like failed index was from previous batch. The reason is that readCancelToken timeout wasn't enought
             // to get response from apns. 
             // So put notifications from current batch again to queue and use new socket for next batches
-            // TODO: check that notifications from current batch weren't sent
             if (failedIndex < 0)
             {
-                Log.Info("APNS-Client[{0}]: Cant find failing notification {1} in current batch", id, identifier);
-
-                EnqueRemainingBatchItems();
+                Log.Info ("APNS-Client[{0}]: Cant find failed notification {1} in current batch", id, identifier);
+                EnqueRemainingBatchItems ();
                 return;
             }
 
@@ -299,13 +297,13 @@ namespace PushSharp.Apple
         private void EnqueRemainingBatchItems()
         {
             foreach (var s in sent)
-                notifications.Enqueue(s.Notification);
+                notifications.Enqueue (s.Notification);
 
             // Clear our sent list
-            sent.Clear();
+            sent.Clear ();
 
             // Apple will close our connection after this anyway
-            disconnect();
+            disconnect ();
         }
 
         bool socketCanWrite ()
@@ -321,10 +319,10 @@ namespace PushSharp.Apple
 
             // looks like response for previous batch wasn't read (and some errors were in previous batch)
             // Unfortunatelly we already notified client that notifications were sent. 
-            // But at least we won't use this socket for new batch...
+            // But at least we won't use this socket for new batch because otherwise new enqueued notifications won't be sent too...
             if (client.Available > 0)
             {
-                Log.Info("APNS-Client[{0}]: Previous batch wasn't processed correctly. Try to increase ResponseWaitTimeout");
+                Log.Info ("APNS-Client[{0}]: Previous batch wasn't processed correctly. Try to increase ResponseWaitTimeout");
                 return false;
             }
 


### PR DESCRIPTION
Sometimes 750ms is not enough to [get response from apns](https://github.com/Redth/PushSharp/blob/master/PushSharp.Apple/ApnsConnection.cs#L206) when there is an error in batch

In this case all messages in batch [marked as sent](https://github.com/Redth/PushSharp/blob/master/PushSharp.Apple/ApnsConnection.cs#L233) and connection is reused for new batches.

During sending next batch error is read, but [there is no failed notification in current batch and reader do nothing](https://github.com/Redth/PushSharp/blob/master/PushSharp.Apple/ApnsConnection.cs#L257)

As a result notifications from this batch are not marked as sent or failed. Also next batches won't be sent because "error" connection is not closed and ApnsConnection instance continues to use it.

************************************
To fix this problem:
- socketCanWrite -> return false if there are available bytes to read in current socket, because it's error from previous batch and new notifications wroten to this connection won't be sent
- if reader can't find index of failed notification ->  push notifications again to queue and close connection
- added ResponseWaitTimeout into configuration to make it's possible to increase timeout for waiting response from apns (if 750ms is not enough too often)

*******************

PS: there is already setting called [MillisecondsToWaitBeforeMessageDeclaredSuccess](https://github.com/Redth/PushSharp/blob/master/PushSharp.Apple/ApnsConfiguration.cs#L79), not sure if it might be used instead of new one ResponseWaitTimeout 