### PR TITLE
Use a Proxy when connecting to Google Cloud Messaging (GCM)

### DIFF
--- a/PushSharp.Google/GcmConfiguration.cs
+++ b/PushSharp.Google/GcmConfiguration.cs
@@ -24,6 +24,30 @@ namespace PushSharp.Google
             this.ValidateServerCertificate = false;
         }
 
+        public void SetProxy(string host, int port)
+        {
+            UseProxy = true;
+            ProxyHost = host;
+            ProxyPort = port;
+            ProxyCredentials = CredentialCache.DefaultNetworkCredentials;
+        }
+
+        public void SetProxy(string host, int port, string username, string pass, string domain)
+        {
+            UseProxy = true;
+            ProxyHost = host;
+            ProxyPort = port;
+            ProxyCredentials = new NetworkCredential(username, pass, domain);
+        }
+
+        public bool UseProxy { get; private set; }
+
+        public string ProxyHost { get; private set; }
+
+        public int ProxyPort { get; private set; }
+
+        public NetworkCredential ProxyCredentials { get; private set; }
+
         public string SenderID { get; private set; }
 
         public string SenderAuthToken { get; private set; }


### PR DESCRIPTION
I needed to use PushSharp with a proxy connecting to GCM. To do it I had to download the PushSharp.Core and PushSharp.Google, modify the Google dll and use it locally in my project. 
The files modified are GcmServiceConnection.cs and GcmConfiguration.cs