### PR TITLE
Fixed WNS accesstoken renewal.

### DIFF
--- a/PushSharp.Windows/WnsTokenAccessManager.cs
+++ b/PushSharp.Windows/WnsTokenAccessManager.cs
@@ -28,6 +28,7 @@ namespace PushSharp.Windows
                     Log.Info ("Renewing Access Token");
                     renewAccessTokenTask = RenewAccessToken ();
                     await renewAccessTokenTask;
+                    renewAccessTokenTask = null;
                 } else {
                     Log.Info ("Waiting for access token");
                     await renewAccessTokenTask;


### PR DESCRIPTION
#691 
The WNS accesstoken would not be renewed after it expired. The stored task cannot be executed twice because it is in the RanToCompletion state and will therefore return immediately leading to failing WNS notifications.