### PR TITLE
Added support for higher TLS versions

### DIFF
--- a/PushSharp.Apple/ApnsConnection.cs
+++ b/PushSharp.Apple/ApnsConnection.cs
@@ -354,7 +354,8 @@ namespace PushSharp.Apple
                     (sender, targetHost, localCerts, remoteCert, acceptableIssuers) => certificate);
 
                 try {
-                    stream.AuthenticateAsClient (Configuration.Host, certificates, System.Security.Authentication.SslProtocols.Tls, false);
+                    var tls = System.Security.Authentication.SslProtocols.Tls | System.Security.Authentication.SslProtocols.Tls11 | System.Security.Authentication.SslProtocols.Tls12;
+                    stream.AuthenticateAsClient(Configuration.Host, certificates, tls, false);
                 } catch (System.Security.Authentication.AuthenticationException ex) {
                     throw new ApnsConnectionException ("SSL Stream Failed to Authenticate as Client", ex);
                 }

--- a/PushSharp.Apple/ApnsFeedbackService.cs
+++ b/PushSharp.Apple/ApnsFeedbackService.cs
@@ -38,7 +38,8 @@ namespace PushSharp.Apple
                 (sender, cert, chain, sslErrs) => { return true; },
                 (sender, targetHost, localCerts, remoteCert, acceptableIssuers) => { return certificate; });
 
-            stream.AuthenticateAsClient(Configuration.FeedbackHost, certificates, System.Security.Authentication.SslProtocols.Tls, false);
+            var tls = System.Security.Authentication.SslProtocols.Tls | System.Security.Authentication.SslProtocols.Tls11 | System.Security.Authentication.SslProtocols.Tls12;
+            stream.AuthenticateAsClient(Configuration.FeedbackHost, certificates, tls, false);
 
 
             //Set up


### PR DESCRIPTION
Added support for higher TLS version. 
Currently pushsharp only work on TLS1.0. Added a fix to support TLS1.1 and TLS1.2