### PR TITLE
Added additional error handling for invalid apns device registration ids

### DIFF
--- a/PushSharp.Windows/WnsConnection.cs
+++ b/PushSharp.Windows/WnsConnection.cs
@@ -64,7 +64,10 @@ namespace PushSharp.Windows
 
             http.DefaultRequestHeaders.TryAddWithoutValidation ("X-WNS-Type", string.Format ("wns/{0}", notification.Type.ToString().ToLower ()));
 
-            if(!http.DefaultRequestHeaders.Contains("Authorization")) //prevent double values
+            if (notification.Priority != WnsPriority.Unspecified)
+                http.DefaultRequestHeaders.TryAddWithoutValidation("X-WNS-PRIORITY", ((int)notification.Priority).ToString());
+
+            if (!http.DefaultRequestHeaders.Contains("Authorization")) //prevent double values
                 http.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "Bearer " + accessToken);
 
             if (notification.RequestForStatus.HasValue)

--- a/PushSharp.Windows/WnsNotification.cs
+++ b/PushSharp.Windows/WnsNotification.cs
@@ -14,6 +14,8 @@ namespace PushSharp.Windows
 
         public abstract WnsNotificationType Type { get; }
 
+        public WnsPriority Priority { get; set; }
+
         public bool IsDeviceRegistrationIdValid ()
         {
             return true;

--- a/PushSharp.Windows/WnsNotificationStatus.cs
+++ b/PushSharp.Windows/WnsNotificationStatus.cs
@@ -43,5 +43,14 @@ namespace PushSharp.Windows
         Toast,
         Raw
     }
+
+    public enum WnsPriority
+    {
+        Unspecified = 0,
+        High = 1,
+        Meduim = 2,
+        Low = 3,
+        VeryLow = 4
+    }
 }
 


### PR DESCRIPTION
Now when an error occurs during connection we are checking each notification for a bad device registration id and if we find any we re-queue the notifications and send InvalidToken errors for each one.

This code was adapted from code written by @ShalvaHMO here: https://github.com/Redth/PushSharp/issues/713

This code was written to solve issue: #713 