### PR TITLE
Changed keepalive period from 20 to 3 minutes

### DIFF
--- a/PushSharp.Apple/ApnsConfiguration.cs
+++ b/PushSharp.Apple/ApnsConfiguration.cs
@@ -91,7 +91,7 @@ namespace PushSharp.Apple
 
             ValidateServerCertificate = false;
 
-            KeepAlivePeriod = TimeSpan.FromMinutes (20);
+            KeepAlivePeriod = TimeSpan.FromMinutes (3);
             KeepAliveRetryPeriod = TimeSpan.FromSeconds (30);
 
             InternalBatchSize = 1000;


### PR DESCRIPTION
Changed keepalive period of Apns configuration for azure tcp timeout.