### PR TITLE
Updated ApnsConnection createBatch

### DIFF
--- a/PushSharp.Apple/ApnsConnection.cs
+++ b/PushSharp.Apple/ApnsConnection.cs
@@ -154,6 +154,7 @@ namespace PushSharp.Apple
                     }
 
                     foreach (var n in toSend) {
+                        // If the notification failed validation before being sent (i.e. it was skipped)
                         if (n.State == NotificationState.Failed)
                             continue;
 
@@ -164,7 +165,8 @@ namespace PushSharp.Apple
             } catch (Exception ex) {
                 Log.Error ("APNS-CLIENT[{0}]: Send Batch Error: Batch ID={1}, Error={2}", id, batchId, ex);
                 foreach (var n in toSend) {
-                    // If the notification has already failed, don't fail it again - we want the original error intact (and CompleteFailed raises an exception if called twice on the same notification)
+                    // If the notification has already failed, don't fail it again (it's possible it failed validation already)
+                    // - we want the original error intact (and CompleteFailed raises an exception if called twice on the same notification)
                     if (n.State == NotificationState.Failed)
                         continue;
 
@@ -194,7 +196,6 @@ namespace PushSharp.Apple
             
             var batchData = new List<byte> ();
 
-            List<CompletableApnsNotification> failedValidation = new List<CompletableApnsNotification>();
             // Add all the frame data
             foreach (var n in toSend) {
                 try {


### PR DESCRIPTION
Fixed one ApnsNotification failing validation in ToBytes() causing the whole batch to fail - now triggers CompleteFailed for the notifications that fail validation, skips them and continues to send the rest. Doesn't rely on a regex to find the failed notifications (as soon as they fail it removes them from the payload and calls the failed event). Also now tracks the state of the CompletableApnsNotification as they can fail before being sent now (during validation). Written to solve: #713