### PR TITLE
Test Broker Send Many using interlock

### DIFF
--- a/PushSharp.Tests/BrokerTests.cs
+++ b/PushSharp.Tests/BrokerTests.cs
@@ -25,10 +25,10 @@ namespace PushSharp.Tests
 
             var broker = new TestServiceBroker ();
             broker.OnNotificationFailed += (notification, exception) => {
-                failed++;
+                Interlocked.Increment(ref failed);
             };
             broker.OnNotificationSucceeded += (notification) => {
-                succeeded++;  
+                Interlocked.Increment(ref succeeded);
             };
 			broker.Start ();
 			broker.ChangeScale (1);


### PR DESCRIPTION
The test appears to only run a single worker, but the increment count
values themselves still may need synchronization with the original test
thread.

Fixes #896