### PR TITLE
Allow GCM proxy config

### DIFF
--- a/PushSharp.Google/GcmConfiguration.cs
+++ b/PushSharp.Google/GcmConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 
 namespace PushSharp.Google
 {
@@ -38,6 +39,8 @@ namespace PushSharp.Google
         {
             GcmUrl = url;
         }
+
+        public WebProxy Proxy { get; set; }
     }
 }
 

--- a/PushSharp.Google/GcmServiceConnection.cs
+++ b/PushSharp.Google/GcmServiceConnection.cs
@@ -38,7 +38,17 @@ namespace PushSharp.Google
         public GcmServiceConnection (GcmConfiguration configuration)
         {
             Configuration = configuration;
-            http = new HttpClient ();
+            if (null != configuration.Proxy)
+            {
+                var httpHandler = new HttpClientHandler
+                {
+                    Proxy = configuration.Proxy
+                };
+                http = new HttpClient(httpHandler, true);
+            } else
+            {
+                http = new HttpClient();
+            }
 
             http.DefaultRequestHeaders.UserAgent.Clear ();
             http.DefaultRequestHeaders.UserAgent.Add (new ProductInfoHeaderValue ("PushSharp", "3.0"));


### PR DESCRIPTION
This PR adds support for using a proxy when sending GCM notifications.

Partially fixes https://github.com/Redth/PushSharp/issues/664.

Related (old PR): https://github.com/Redth/PushSharp/pull/390