### PR TITLE
Added X-WNS-PRIORITY header for WNS notifications

### DIFF
--- a/PushSharp.Windows/WnsConnection.cs
+++ b/PushSharp.Windows/WnsConnection.cs
@@ -64,7 +64,10 @@ namespace PushSharp.Windows
 
             http.DefaultRequestHeaders.TryAddWithoutValidation ("X-WNS-Type", string.Format ("wns/{0}", notification.Type.ToString().ToLower ()));
 
-            if(!http.DefaultRequestHeaders.Contains("Authorization")) //prevent double values
+            if (notification.Priority != WnsPriority.Unspecified)
+                http.DefaultRequestHeaders.TryAddWithoutValidation("X-WNS-PRIORITY", ((int)notification.Priority).ToString());
+
+            if (!http.DefaultRequestHeaders.Contains("Authorization")) //prevent double values
                 http.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "Bearer " + accessToken);
 
             if (notification.RequestForStatus.HasValue)

--- a/PushSharp.Windows/WnsNotification.cs
+++ b/PushSharp.Windows/WnsNotification.cs
@@ -14,6 +14,8 @@ namespace PushSharp.Windows
 
         public abstract WnsNotificationType Type { get; }
 
+        public WnsPriority Priority { get; set; }
+
         public bool IsDeviceRegistrationIdValid ()
         {
             return true;

--- a/PushSharp.Windows/WnsNotificationStatus.cs
+++ b/PushSharp.Windows/WnsNotificationStatus.cs
@@ -43,5 +43,14 @@ namespace PushSharp.Windows
         Toast,
         Raw
     }
+
+    public enum WnsPriority
+    {
+        Unspecified = 0,
+        High = 1,
+        Meduim = 2,
+        Low = 3,
+        VeryLow = 4
+    }
 }
 


### PR DESCRIPTION
X-WNS-PRIORITY can be a useful header to specify a particular notification's priority. If the priority is not specified for a notification it will not add the header. This will result in the notification getting the default priority. See more at https://docs.microsoft.com/en-us/windows/uwp/design/shell/tiles-and-notifications/wns-notification-priorities